### PR TITLE
CLM-24219 The scan_result.json file keeps showing as owned by root

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.neuvector</groupId>
   <artifactId>scanner</artifactId>
-  <version>1.8</version>
+  <version>1.9</version>
   <packaging>jar</packaging>
 
   <name>NeuVector Scanner API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,18 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <exclusions>
+        <exclusion>
+          <!-- using junit:junit instead -->
+          <groupId>junit</groupId>
+          <artifactId>junit-dep</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -47,18 +47,6 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-rules</artifactId>
-      <version>1.19.0</version>
-      <exclusions>
-        <exclusion>
-          <!-- using junit:junit instead -->
-          <groupId>junit</groupId>
-          <artifactId>junit-dep</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -339,32 +339,34 @@ public class Scanner
     }
 
     static String[] getDockerGroupCmdArgs(String scanReportPath) {
-         String[] cmdArgs = {"", ""};
+        String[] cmdGroupArgs = {"", ""};
         if (!scanResultsFileExist(scanReportPath)) {
-            cmdArgs[0] = "-u";
-            cmdArgs [1] = executeCommand("id -g");
-            return cmdArgs;
+            cmdGroupArgs[0] = "-u";
+            cmdGroupArgs[1] = executeCommand("id -g");
+            return cmdGroupArgs;
         }
-        return cmdArgs;
+        return cmdGroupArgs;
     }
 
     private static String executeCommand(String command) {
         StringBuilder output = new StringBuilder();
         try {
-            String line = "";
             Process proc = Runtime.getRuntime().exec(command);
-            // Read the output
-            BufferedReader reader =
-                    new BufferedReader(new InputStreamReader(proc.getInputStream()));
+            getExecValueFromBuffer(output, proc);
+        } catch (Exception e) {
+        }
+        return output.toString();
+    }
 
+    private static void getExecValueFromBuffer(StringBuilder output, Process proc) throws IOException, InterruptedException {
+        String line;
+        try (BufferedReader reader =
+                     new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
             while ((line = reader.readLine()) != null) {
                 output.append(line);
             }
             proc.waitFor();
-            reader.close();
-        } catch (Exception e) {
         }
-        return output.toString();
     }
 
     private static boolean scanResultsFileExist(String scanReportPath) {

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -341,6 +341,8 @@ public class Scanner
 
     static String[] getDockerGroupCmdArgs(String scanReportPath) {
         String[] cmdGroupArgs = {"", ""};
+        if(!Boolean.valueOf(System.getenv("NEXUS_CONTAINER_SCANNING_USE_USER_ID")))
+            return cmdGroupArgs;
 
         // no user arg if file exists and it is owned by root
         Boolean ownedByRoot = ownedByRoot(scanReportPath);

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -267,9 +267,10 @@ public class Scanner
     }
 
     private static ScanRepoReportData runScan(String[] cmdArgs, String scanReportPath, String[] credentials) {
-        if (isRootFile(getScanReportPath(scanReportPath))) {
+        Boolean isRootFile = isRootFile(getScanReportPath(scanReportPath));
+        if (isRootFile == null || isRootFile) {
             //we need to clean the empty args
-            //cmdArgs = Arrays.stream(cmdArgs).filter(s -> !s.isEmpty()).toArray(String[]::new);
+            cmdArgs = Arrays.stream(cmdArgs).filter(s -> !s.isEmpty()).toArray(String[]::new);
         }
 
         String errorMessage = runCMD(cmdArgs);
@@ -350,12 +351,12 @@ public class Scanner
         return cmdGroupArgs;
     }
 
-    private static boolean isRootFile(String scanReportPath)  {
+    private static Boolean isRootFile(String scanReportPath)  {
         File scanResultFileJson = new File(scanReportPath);
         try {
             return scanResultsFileExist(scanReportPath) && getUserPrincipal(scanReportPath, scanResultFileJson).getName().equals("root");
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            return null;
         }
     }
 

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -362,7 +362,7 @@ public class Scanner
     private static Boolean ownedByRoot(String scanReportPath)  {
         File scanResultFileJson = new File(scanReportPath);
         try {
-            return "root".equals(getUserPrincipal(scanReportPath, scanResultFileJson).getName());
+            return scanResultsFileExist(scanReportPath) && "root".equals(getUserPrincipal(scanReportPath, scanResultFileJson).getName());
         } catch (IOException e) {
             return null;
         }

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -43,14 +43,14 @@ public class Scanner
       * @param scanLayers Scan image layers 
       * @return ScanRepoReportData
       */
-    public static ScanRepoReportData scanRegistry(Registry registry, NVScanner nvScanner, String license, Boolean scanLayers) {
+     public static ScanRepoReportData scanRegistry(Registry registry, NVScanner nvScanner, String license, Boolean scanLayers) {
 
         String errorMessage = "";
         if(registry == null || nvScanner == null){
             errorMessage = "The Registry and nvScanner can't be null.";
         }
 
-        String[] dockerGroupCmdArgs = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()));
+        String[] dockerGroupCmdArgs = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()), nvScanner.isScanWithNotRootUser());
 
         errorMessage = pullDockerImage(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL(), nvScanner.getNvRegistryUser(), nvScanner.getNvRegistryPassword());
         ScanRepoReportData reportData = null;
@@ -113,7 +113,7 @@ public class Scanner
             errorMessage = "The image and nvScanner can't be null.";
         }
 
-        String[] dockerGroupCmdArgs = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()));
+        String[] dockerGroupCmdArgs = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()), nvScanner.isScanWithNotRootUser());
         errorMessage = pullDockerImage(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL(), nvScanner.getNvRegistryUser(), nvScanner.getNvRegistryPassword());
         ScanRepoReportData reportData = null;
 
@@ -339,9 +339,9 @@ public class Scanner
         return message.replace(credential, "******");
     }
 
-    static String[] getDockerGroupCmdArgs(String scanReportPath) {
+    static String[] getDockerGroupCmdArgs(String scanReportPath, Boolean scanWithNotRootUser) {
         String[] cmdGroupArgs = {"", ""};
-        if(!Boolean.valueOf(System.getenv("NEXUS_CONTAINER_SCANNING_USE_USER_ID")))
+        if(!scanWithNotRootUser)
             return cmdGroupArgs;
 
         // no user arg if file exists and it is owned by root

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -390,7 +390,7 @@ public class Scanner
         }
     }
 
-    private static boolean scanResultsFileExist(String scanReportPath) {
+    private static boolean scanResultsFileExist(String scanResultFilePath) {
         File file = new File(scanReportPath);
         return file.exists();
     }

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -341,12 +341,13 @@ public class Scanner
 
     static String[] getDockerGroupCmdArgs(String scanReportPath, Boolean includeUserId) {
         String[] cmdGroupArgs = {"", ""};
-        if(!includeUserId)
+        if(!includeUserId){
             return cmdGroupArgs;
+        }
 
-        // no user arg if file exists and it is owned by root
+        // No user arg if file exists, and it is owned by root
         Boolean ownedByRoot = ownedByRoot(scanReportPath);
-        if (scanResultsFileExist(scanReportPath) && ownedByRoot != null && ownedByRoot) {
+        if (ownedByRoot != null && ownedByRoot) {
             return cmdGroupArgs;
         }
 

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -362,7 +362,7 @@ public class Scanner
     private static Boolean ownedByRoot(String scanReportPath)  {
         File scanResultFileJson = new File(scanReportPath);
         try {
-            return scanResultsFileExist(scanReportPath) && getUserPrincipal(scanReportPath, scanResultFileJson).getName().equals("root");
+            return "root".equals(getUserPrincipal(scanReportPath, scanResultFileJson).getName());
         } catch (IOException e) {
             return null;
         }
@@ -391,8 +391,8 @@ public class Scanner
     }
 
     private static boolean scanResultsFileExist(String scanResultFilePath) {
-        File scanResultFile = new File(scanReportPath);
-        return file.exists();
+        File scanResultFile = new File(scanResultFilePath);
+        return scanResultFile.exists();
     }
 
     private static UserPrincipal getUserPrincipal(String mountPath, File file) throws IOException {

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -391,7 +391,7 @@ public class Scanner
     }
 
     private static boolean scanResultsFileExist(String scanResultFilePath) {
-        File file = new File(scanReportPath);
+        File scanResultFile = new File(scanReportPath);
         return file.exists();
     }
 

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -267,11 +267,8 @@ public class Scanner
     }
 
     private static ScanRepoReportData runScan(String[] cmdArgs, String scanReportPath, String[] credentials) {
-        Boolean isRootFile = isRootFile(getScanReportPath(scanReportPath));
-        if (isRootFile == null || isRootFile) {
-            //we need to clean the empty args
-            cmdArgs = Arrays.stream(cmdArgs).filter(s -> !s.isEmpty()).toArray(String[]::new);
-        }
+        //we need to clean the empty args
+        cmdArgs = Arrays.stream(cmdArgs).filter(s -> !s.isEmpty()).toArray(String[]::new);
 
         String errorMessage = runCMD(cmdArgs);
 

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -344,9 +344,10 @@ public class Scanner
 
     static String[] getDockerGroupCmdArgs(String scanReportPath) {
         String[] cmdGroupArgs = {"", ""};
-        if (!scanResultsFileExist(scanReportPath) || !isRootFile(scanReportPath)) {
+        String UID = executeCommand("id -u");
+        if (!scanResultsFileExist(scanReportPath) || !isRootFile(scanReportPath) && (UID!= null && !UID.isEmpty())) {
             cmdGroupArgs[0] = "-u";
-            cmdGroupArgs[1] = executeCommand("id -u");
+            cmdGroupArgs[1] = UID;
         }
         return cmdGroupArgs;
     }
@@ -366,6 +367,7 @@ public class Scanner
             Process proc = Runtime.getRuntime().exec(command);
             getExecValueFromBuffer(output, proc);
         } catch (Exception e) {
+            return null;
         }
         return output.toString();
     }

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -50,7 +50,7 @@ public class Scanner
             errorMessage = "The Registry and nvScanner can't be null.";
         }
 
-        String[] dockerGroupCmdArgs = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()), nvScanner.isScanWithNotRootUser());
+        String[] dockerGroupCmdArgs = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()), nvScanner.isIncludeUserId());
 
         errorMessage = pullDockerImage(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL(), nvScanner.getNvRegistryUser(), nvScanner.getNvRegistryPassword());
         ScanRepoReportData reportData = null;
@@ -113,7 +113,7 @@ public class Scanner
             errorMessage = "The image and nvScanner can't be null.";
         }
 
-        String[] dockerGroupCmdArgs = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()), nvScanner.isScanWithNotRootUser());
+        String[] dockerGroupCmdArgs = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()), nvScanner.isIncludeUserId());
         errorMessage = pullDockerImage(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL(), nvScanner.getNvRegistryUser(), nvScanner.getNvRegistryPassword());
         ScanRepoReportData reportData = null;
 
@@ -339,9 +339,9 @@ public class Scanner
         return message.replace(credential, "******");
     }
 
-    static String[] getDockerGroupCmdArgs(String scanReportPath, Boolean scanWithNotRootUser) {
+    static String[] getDockerGroupCmdArgs(String scanReportPath, Boolean includeUserId) {
         String[] cmdGroupArgs = {"", ""};
-        if(!scanWithNotRootUser)
+        if(!includeUserId)
             return cmdGroupArgs;
 
         // no user arg if file exists and it is owned by root

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -50,7 +50,7 @@ public class Scanner
             errorMessage = "The Registry and nvScanner can't be null.";
         }
 
-        String dockerGroupCmdArgs[] = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()));
+        String[] dockerGroupCmdArgs = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()));
 
         errorMessage = pullDockerImage(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL(), nvScanner.getNvRegistryUser(), nvScanner.getNvRegistryPassword());
         ScanRepoReportData reportData = null;
@@ -113,7 +113,7 @@ public class Scanner
             errorMessage = "The image and nvScanner can't be null.";
         }
 
-        String dockerGroupCmdArgs[] = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()));
+        String[] dockerGroupCmdArgs = getDockerGroupCmdArgs(getScanReportPath(nvScanner.getNvMountPath()));
         errorMessage = pullDockerImage(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL(), nvScanner.getNvRegistryUser(), nvScanner.getNvRegistryPassword());
         ScanRepoReportData reportData = null;
 
@@ -269,7 +269,7 @@ public class Scanner
     private static ScanRepoReportData runScan(String[] cmdArgs, String scanReportPath, String[] credentials) {
         if (isRootFile(getScanReportPath(scanReportPath))) {
             //we need to clean the empty args
-            cmdArgs = Arrays.stream(cmdArgs).filter(s -> !s.isEmpty()).toArray(String[]::new);
+            //cmdArgs = Arrays.stream(cmdArgs).filter(s -> !s.isEmpty()).toArray(String[]::new);
         }
 
         String errorMessage = runCMD(cmdArgs);
@@ -346,15 +346,14 @@ public class Scanner
         if (!scanResultsFileExist(scanReportPath) || !isRootFile(scanReportPath)) {
             cmdGroupArgs[0] = "-u";
             cmdGroupArgs[1] = executeCommand("id -u");
-            return cmdGroupArgs;
         }
         return cmdGroupArgs;
     }
 
     private static boolean isRootFile(String scanReportPath)  {
-        File file = new File(scanReportPath);
+        File scanResultFileJson = new File(scanReportPath);
         try {
-            return scanResultsFileExist(scanReportPath) && getUserPrincipal(scanReportPath, file).getName().equals("root");
+            return scanResultsFileExist(scanReportPath) && getUserPrincipal(scanReportPath, scanResultFileJson).getName().equals("root");
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -44,7 +44,8 @@ public class Scanner
             errorMessage = "The Registry and nvScanner can't be null.";
         }
 
-        
+        String dockerUserAndGroup = getDockerUserAndGroup();
+
         errorMessage = pullDockerImage(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL(), nvScanner.getNvRegistryUser(), nvScanner.getNvRegistryPassword());
         ScanRepoReportData reportData = null;
 
@@ -55,20 +56,20 @@ public class Scanner
             String[] credentials = {registry.getLoginPassword(), license};
             if( scanLayers ) {
                 if (registry.getLoginUser() == null && registry.getLoginPassword() == null) {
-                    String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), "-e", "SCANNER_SCAN_LAYERS=true", getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
+                    String[] cmdArgs = {"docker", "run", "-u", dockerUserAndGroup, "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), "-e", "SCANNER_SCAN_LAYERS=true", getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
                     reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
                 }
                 else {
-                    String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), "-e", "SCANNER_REGISTRY_USERNAME=" + registry.getLoginUser(), "-e", "SCANNER_REGISTRY_PASSWORD=" + registry.getLoginPassword() , "-e", "SCANNER_SCAN_LAYERS=true", getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
+                    String[] cmdArgs = {"docker", "run", "-u", dockerUserAndGroup, "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), "-e", "SCANNER_REGISTRY_USERNAME=" + registry.getLoginUser(), "-e", "SCANNER_REGISTRY_PASSWORD=" + registry.getLoginPassword() , "-e", "SCANNER_SCAN_LAYERS=true", getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
                     reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
                 }
             }else {
                 if (registry.getLoginUser() == null && registry.getLoginPassword() == null) {
-                    String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
+                    String[] cmdArgs = {"docker", "run", "-u", dockerUserAndGroup, "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
                     reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
                 }
                 else {
-                    String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), "-e", "SCANNER_REGISTRY_USERNAME=" + registry.getLoginUser(), "-e", "SCANNER_REGISTRY_PASSWORD=" + registry.getLoginPassword() , getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
+                    String[] cmdArgs = {"docker", "run", "-u", dockerUserAndGroup, "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), "-e", "SCANNER_REGISTRY_USERNAME=" + registry.getLoginUser(), "-e", "SCANNER_REGISTRY_PASSWORD=" + registry.getLoginPassword() , getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
                     reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
                 }
             }
@@ -106,6 +107,8 @@ public class Scanner
             errorMessage = "The image and nvScanner can't be null.";
         }
 
+        String dockerUserAndGroup = getDockerUserAndGroup();
+
         errorMessage = pullDockerImage(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL(), nvScanner.getNvRegistryUser(), nvScanner.getNvRegistryPassword());
         ScanRepoReportData reportData = null;
 
@@ -115,10 +118,10 @@ public class Scanner
         }else{
             String[] credentials = {license};
             if( scanLayers ){
-                String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + image.getImageName(), "-e", "SCANNER_TAG=" + image.getImageTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_SCAN_LAYERS=true", getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
+                String[] cmdArgs = {"docker", "run", "-u", dockerUserAndGroup, "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + image.getImageName(), "-e", "SCANNER_TAG=" + image.getImageTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_SCAN_LAYERS=true", getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
                 reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
             }else{
-                String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + image.getImageName(), "-e", "SCANNER_TAG=" + image.getImageTag(), "-e", "SCANNER_LICENSE=" + license, getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
+                String[] cmdArgs = {"docker", "run", "-u", dockerUserAndGroup, "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + image.getImageName(), "-e", "SCANNER_TAG=" + image.getImageTag(), "-e", "SCANNER_LICENSE=" + license, getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
                 reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
             }
         }
@@ -327,6 +330,30 @@ public class Scanner
 
     private static String maskCredential(String message, String credential){
         return message.replace(credential, "******");
+    }
+
+    private static String getDockerUserAndGroup() {
+        String user = executeBashCommand("id -u");
+        String group = executeBashCommand("id -g");
+        return String.format("%s:%s", user,group);
+    }
+
+    private static String executeBashCommand(String command) {
+        StringBuilder output = new StringBuilder();
+        try {
+            String line = "";
+            Process proc = Runtime.getRuntime().exec(command);
+            // Read the output
+            BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(proc.getInputStream()));
+
+            while ((line = reader.readLine()) != null) {
+                output.append(line);
+            }
+            proc.waitFor();
+        } catch (Exception e) {
+        }
+        return output.toString();
     }
 
     public static String deleteDockerImagesByLabelKey(String label) {

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -341,15 +341,22 @@ public class Scanner
 
     static String[] getDockerGroupCmdArgs(String scanReportPath) {
         String[] cmdGroupArgs = {"", ""};
+
+        // no user arg if file exists and it is owned by root
+        Boolean ownedByRoot = ownedByRoot(scanReportPath);
+        if (scanResultsFileExist(scanReportPath) && ownedByRoot != null && ownedByRoot) {
+            return cmdGroupArgs;
+        }
+
         String UID = executeCommand("id -u");
-        if (!scanResultsFileExist(scanReportPath) || !isRootFile(scanReportPath) && (UID!= null && !UID.isEmpty())) {
+        if ((UID != null && !UID.isEmpty())) {
             cmdGroupArgs[0] = "-u";
             cmdGroupArgs[1] = UID;
         }
         return cmdGroupArgs;
     }
 
-    private static Boolean isRootFile(String scanReportPath)  {
+    private static Boolean ownedByRoot(String scanReportPath)  {
         File scanResultFileJson = new File(scanReportPath);
         try {
             return scanResultsFileExist(scanReportPath) && getUserPrincipal(scanReportPath, scanResultFileJson).getName().equals("root");

--- a/src/main/java/com/neuvector/model/NVScanner.java
+++ b/src/main/java/com/neuvector/model/NVScanner.java
@@ -6,6 +6,7 @@ public class NVScanner {
     String nvRegistryUser;
     String nvRegistryPassword;
     String nvMountPath;
+    Boolean scanWithNotRootUser;
     
     public NVScanner(){}
 
@@ -30,12 +31,13 @@ public class NVScanner {
      * @param nvRegistryPassword The password to login the registry.
      * @param nvMountPath  The mount path mapping to the path inside the NeuVector Scanner container. It is the path to store the scan result. It is optional. If you don't pass in <code>nvMountPath</code>, it will use the default path "/var/neuvector"
      */
-    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath){
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Boolean scanWithNotRootUser){
         this.nvRegistryURL = nvRegistryURL;
         this.nvScannerImage = nvScannerImage;
         this.nvRegistryUser = nvRegistryUser;
         this.nvRegistryPassword = nvRegistryPassword;
         this.nvMountPath = nvMountPath;
+        this.scanWithNotRootUser = scanWithNotRootUser;
     }
 
     /**
@@ -106,6 +108,14 @@ public class NVScanner {
      */
     public void setNvMountPath(String nvMountPath) {
         this.nvMountPath = nvMountPath;
+    }
+
+    public Boolean isScanWithNotRootUser() {
+        return scanWithNotRootUser;
+    }
+
+    public void setScanWithNotRootUser(Boolean scanWithNotRootUser) {
+        this.scanWithNotRootUser = scanWithNotRootUser;
     }
     
     

--- a/src/main/java/com/neuvector/model/NVScanner.java
+++ b/src/main/java/com/neuvector/model/NVScanner.java
@@ -6,7 +6,7 @@ public class NVScanner {
     String nvRegistryUser;
     String nvRegistryPassword;
     String nvMountPath;
-    Boolean scanWithNotRootUser;
+    Boolean includeUserId;
     
     public NVScanner(){}
 
@@ -31,13 +31,13 @@ public class NVScanner {
      * @param nvRegistryPassword The password to login the registry.
      * @param nvMountPath  The mount path mapping to the path inside the NeuVector Scanner container. It is the path to store the scan result. It is optional. If you don't pass in <code>nvMountPath</code>, it will use the default path "/var/neuvector"
      */
-    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Boolean scanWithNotRootUser){
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Boolean includeUserId){
         this.nvRegistryURL = nvRegistryURL;
         this.nvScannerImage = nvScannerImage;
         this.nvRegistryUser = nvRegistryUser;
         this.nvRegistryPassword = nvRegistryPassword;
         this.nvMountPath = nvMountPath;
-        this.scanWithNotRootUser = scanWithNotRootUser;
+        this.includeUserId = includeUserId;
     }
 
     /**
@@ -110,12 +110,12 @@ public class NVScanner {
         this.nvMountPath = nvMountPath;
     }
 
-    public Boolean isScanWithNotRootUser() {
-        return scanWithNotRootUser;
+    public Boolean isIncludeUserId() {
+        return includeUserId;
     }
 
-    public void setScanWithNotRootUser(Boolean scanWithNotRootUser) {
-        this.scanWithNotRootUser = scanWithNotRootUser;
+    public void setIncludeUserId(Boolean includeUserId) {
+        this.includeUserId = includeUserId;
     }
     
     

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -75,12 +75,10 @@ public class ScannerTest
 
     private static UserPrincipal getUserPrincipal(String mountPath, File file) throws IOException {
         UserPrincipal user = null;
-        if (file.exists()) {
-            Path path = Paths.get(mountPath + "/scan_result.json");
-            FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
-                    FileOwnerAttributeView.class);
-            user = fileOwner.getOwner();
-        }
+        Path path = Paths.get(mountPath + "/scan_result.json");
+        FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
+                FileOwnerAttributeView.class);
+        user = fileOwner.getOwner();
         return user;
     }
 }

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -31,8 +30,8 @@ public class ScannerTest
         String imageName = "songlongtj/alpine";
         String imageTag = "3.6";
         String nvScannerImage = "neuvector/scanner:latest";
-        String nvRegistryUser = "";
-        String nvRegistryPassword = "";
+        String nvRegistryUser = "xxx";
+        String nvRegistryPassword = "xxx";
         String nvRegistryURL = "https://registry.hub.docker.com";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
         File file = new File(mountPath + "/scan_result.json");
@@ -68,8 +67,8 @@ public class ScannerTest
         String repositoryTag = "3.6";
         String nvScannerImage = "neuvector/scanner:latest";
         String nvRegistryURL = registryURL;
-        String nvRegistryUser = "";
-        String nvRegistryPassword = "";
+        String nvRegistryUser = "xxx";
+        String nvRegistryPassword = "xxx";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
         File file = new File(mountPath + "/scan_result.json");
         Path path = Paths.get(mountPath + "/scan_result.json");

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -1,5 +1,6 @@
 package com.neuvector;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.neuvector.model.Image;
@@ -40,7 +41,7 @@ public class ScannerTest
 
         UserPrincipal user = getUserPrincipal(mountPath);
 
-        assertTrue(!user.getName().equals("root") );
+        assertFalse(user.getName().equals("root"));
         assertTrue( scanReportData != null );
     }
 
@@ -66,7 +67,7 @@ public class ScannerTest
 
         UserPrincipal user = getUserPrincipal(mountPath);
 
-        assertTrue(!user.getName().equals("root") );
+        assertFalse(user.getName().equals("root"));
         assertTrue( scanReportData != null );
     }
 

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -9,33 +9,56 @@ import com.neuvector.model.ScanRepoReportData;
 
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileOwnerAttributeView;
+import java.nio.file.attribute.UserPrincipal;
+
 /**
  * Unit tests
  */
 public class ScannerTest 
 {
     @Test
-    public void scanLocalImageTest()
-    {
+    public void scanLocalImageTest() throws IOException {
         String license = "r+wzvemF4mHMIBkvKHXTuuLzw4ML/RW2ARfbC06Qem1VdQ8DXcMWNKbd8GD0uYiLoS9d9XPM8bff4ag66fqwdOa42oNXk9dzP1TTRg0zvVKJNMxbxKAuGMY24x0NlXstc3Jl2BcXq7aTHrlQwzJ/7qD8157+YfcjKJbywbt3WvvdpuoJtJIuKaO9hOfGu9/zbRZznEtZiJj56xaRMVZ/ZkPHIMseRWML7FUr1oft20PYU7ltf1BGPT/LlocAXAJucBpUz5iosRzS1iYJhU4M1kdBhEwQHl6FZXrtzJGYpM21587FyYrkvoIPQNlIijaAOiCXR060PJNfcQzOzEpYRidhVPnHIHQuIn8gcYuU3XwPB9Pq3tGzERpr0aB64EjSSanpcIh/XEhnXijiRP6CfxsHx8RvD/jkXy5VlJpTVFh1Iu7ywE6fePHb3hIe16uCtdYB8fu2p8ksCcnxXbjBUkKvdLLxq5gvOCfCJxknd4GdIS3UJySNblgmlfU6liYcgt555TitN5DAjuMhTaoxj9FoPPwJsl4rrf2+32cqUFI+9+UdNsSd2gWtS/8T2ifPHNVMA7fdPdIWx+/4jXP8u484cLqGG9RutNGPo0k7cmxmgx29FvVOMvpkotD8IZsbCfl8sFHtFRP7PegWYPghZf6yUkw5m4SD+bacVZalnLizZKbDgFuzPmH1LgrroVN1Ngf06JVfO6lDodbAOactsJC7P8DOPRUoOtnCf3ffgshPh+QSTKDOmNvFU51VB7MoLlZiKNaVP6yMqS1bUwxRpI5eehqhqCHy46PWfRHF2EnbiQOyYIjJSY5jE54TzOaKZ613GgdIaMN+mbXg+UWajDevwCvKQo+CrwpBoX72tP/as9G3zIJILaKuXbQRvTtZbgGREMSoLIDxPBYe3FVqMHFg/jUE9iPbsF16JHv/z3EzcAYKwYSyDEyVppTvLjQY0t/Vul4SEj+QWpyW7elAUmatzHdAcX2SB3oDOhUtDyIxw8rtenD9hCOfspJtEFknhtM+Zm1WuoQYRM5/paEVvbHZnu2XHY2cnBtxJZAD8wKktnSPGg3foCXQpQcSEyhfWhVT14WX2/GxgbdwIuxSBcoHlcduca5tKtlKAhJ4kjPPZeQc5A18z48pLRU=";
 
         String imageName = "songlongtj/alpine";
         String imageTag = "3.6";
         String nvScannerImage = "neuvector/scanner:latest";
-        String nvRegistryUser = "xxx";
-        String nvRegistryPassword = "xxx";
+        String nvRegistryUser = "";
+        String nvRegistryPassword = "";
         String nvRegistryURL = "https://registry.hub.docker.com";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        File file = new File(mountPath + "/scan_result.json");
+        Path path = Paths.get(mountPath + "/scan_result.json");
+        FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
+                FileOwnerAttributeView.class);
+        UserPrincipal user = fileOwner.getOwner();
+        InetAddress addr;
+        addr = InetAddress.getLocalHost();
+        String hostname = addr.getHostName();
 
         Image image = new Image(imageName, imageTag);
         NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
 
         ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
+
+        assertTrue( !hostname.contains("root" ));
+        assertTrue( hostname.contains(user.getName()) );
+        assertTrue( file.exists() );
+        assertTrue( file.canWrite() );
+        assertTrue( file.canRead() );
         assertTrue( scanReportData != null );
     }
 
     @Test
-    public void scanRegistryTest(){
+    public void scanRegistryTest() throws IOException {
         String license = "r+wzvemF4mHMIBkvKHXTuuLzw4ML/RW2ARfbC06Qem1VdQ8DXcMWNKbd8GD0uYiLoS9d9XPM8bff4ag66fqwdOa42oNXk9dzP1TTRg0zvVKJNMxbxKAuGMY24x0NlXstc3Jl2BcXq7aTHrlQwzJ/7qD8157+YfcjKJbywbt3WvvdpuoJtJIuKaO9hOfGu9/zbRZznEtZiJj56xaRMVZ/ZkPHIMseRWML7FUr1oft20PYU7ltf1BGPT/LlocAXAJucBpUz5iosRzS1iYJhU4M1kdBhEwQHl6FZXrtzJGYpM21587FyYrkvoIPQNlIijaAOiCXR060PJNfcQzOzEpYRidhVPnHIHQuIn8gcYuU3XwPB9Pq3tGzERpr0aB64EjSSanpcIh/XEhnXijiRP6CfxsHx8RvD/jkXy5VlJpTVFh1Iu7ywE6fePHb3hIe16uCtdYB8fu2p8ksCcnxXbjBUkKvdLLxq5gvOCfCJxknd4GdIS3UJySNblgmlfU6liYcgt555TitN5DAjuMhTaoxj9FoPPwJsl4rrf2+32cqUFI+9+UdNsSd2gWtS/8T2ifPHNVMA7fdPdIWx+/4jXP8u484cLqGG9RutNGPo0k7cmxmgx29FvVOMvpkotD8IZsbCfl8sFHtFRP7PegWYPghZf6yUkw5m4SD+bacVZalnLizZKbDgFuzPmH1LgrroVN1Ngf06JVfO6lDodbAOactsJC7P8DOPRUoOtnCf3ffgshPh+QSTKDOmNvFU51VB7MoLlZiKNaVP6yMqS1bUwxRpI5eehqhqCHy46PWfRHF2EnbiQOyYIjJSY5jE54TzOaKZ613GgdIaMN+mbXg+UWajDevwCvKQo+CrwpBoX72tP/as9G3zIJILaKuXbQRvTtZbgGREMSoLIDxPBYe3FVqMHFg/jUE9iPbsF16JHv/z3EzcAYKwYSyDEyVppTvLjQY0t/Vul4SEj+QWpyW7elAUmatzHdAcX2SB3oDOhUtDyIxw8rtenD9hCOfspJtEFknhtM+Zm1WuoQYRM5/paEVvbHZnu2XHY2cnBtxJZAD8wKktnSPGg3foCXQpQcSEyhfWhVT14WX2/GxgbdwIuxSBcoHlcduca5tKtlKAhJ4kjPPZeQc5A18z48pLRU=";
 
         String registryURL = "https://registry.hub.docker.com";
@@ -45,14 +68,28 @@ public class ScannerTest
         String repositoryTag = "3.6";
         String nvScannerImage = "neuvector/scanner:latest";
         String nvRegistryURL = registryURL;
-        String nvRegistryUser = "xxx";
-        String nvRegistryPassword = "xxx";
+        String nvRegistryUser = "";
+        String nvRegistryPassword = "";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        File file = new File(mountPath + "/scan_result.json");
+        Path path = Paths.get(mountPath + "/scan_result.json");
+        FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
+                FileOwnerAttributeView.class);
+        UserPrincipal user = fileOwner.getOwner();
+        InetAddress addr;
+        addr = InetAddress.getLocalHost();
+        String hostname = addr.getHostName();
 
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
         NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
 
         ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
+
+        assertTrue( !hostname.contains("root" ));
+        assertTrue( hostname.contains(user.getName()) );
+        assertTrue( file.exists() );
+        assertTrue( file.canWrite() );
+        assertTrue( file.canRead() );
         assertTrue( scanReportData != null );
     }
 }

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -34,24 +34,26 @@ public class ScannerTest
         String nvRegistryPassword = "xxx";
         String nvRegistryURL = "https://registry.hub.docker.com";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
-        File file = new File(mountPath + "/scan_result.json");
-        Path path = Paths.get(mountPath + "/scan_result.json");
-        FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
-                FileOwnerAttributeView.class);
-        UserPrincipal user = fileOwner.getOwner();
-        InetAddress addr = InetAddress.getLocalHost();;
-        String hostname = addr.getHostName();
-
         Image image = new Image(imageName, imageTag);
         NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
 
         ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
 
-        assertTrue( !hostname.contains("root" ));
-        assertTrue( hostname.contains(user.getName()) );
-        assertTrue( file.exists() );
-        assertTrue( file.canWrite() );
-        assertTrue( file.canRead() );
+        File file = new File(mountPath + "/scan_result.json");
+        Path path = Paths.get(mountPath + "/scan_result.json");
+
+        if(file.exists()){
+            FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
+                    FileOwnerAttributeView.class);
+            UserPrincipal user = fileOwner.getOwner();
+            InetAddress addr = InetAddress.getLocalHost();;
+            String hostname = addr.getHostName();
+            assertTrue( !hostname.contains("root" ));
+            assertTrue( hostname.contains(user.getName()) );
+            assertTrue( file.canWrite() );
+            assertTrue( file.canRead() );
+        }
+
         assertTrue( scanReportData != null );
     }
 
@@ -66,9 +68,14 @@ public class ScannerTest
         String repositoryTag = "3.6";
         String nvScannerImage = "neuvector/scanner:latest";
         String nvRegistryURL = registryURL;
-        String nvRegistryUser = "xxx";
-        String nvRegistryPassword = "xxx";
+        String nvRegistryUser = "";
+        String nvRegistryPassword = "";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
+
+        ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
+
         File file = new File(mountPath + "/scan_result.json");
         Path path = Paths.get(mountPath + "/scan_result.json");
         FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
@@ -76,11 +83,6 @@ public class ScannerTest
         UserPrincipal user = fileOwner.getOwner();
         InetAddress addr = InetAddress.getLocalHost();;
         String hostname = addr.getHostName();
-
-        Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
-
-        ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
 
         assertTrue( !hostname.contains("root" ));
         assertTrue( hostname.contains(user.getName()) );

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -7,9 +7,10 @@ import com.neuvector.model.NVScanner;
 import com.neuvector.model.Registry;
 import com.neuvector.model.ScanRepoReportData;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,6 +23,9 @@ import java.nio.file.attribute.UserPrincipal;
  */
 public class ScannerTest 
 {
+
+    @Rule
+    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
     @Test
     public void scanLocalImageTest() throws IOException {
         String license = "";
@@ -33,6 +37,7 @@ public class ScannerTest
         String nvRegistryPassword = "";
         String nvRegistryURL = "https://registry.hub.docker.com";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        environmentVariables.set("NEXUS_CONTAINER_SCANNING_USE_USER_ID", "true");
 
         Image image = new Image(imageName, imageTag);
         NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
@@ -59,6 +64,7 @@ public class ScannerTest
         String nvRegistryUser = "";
         String nvRegistryPassword = "";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        environmentVariables.set("NEXUS_CONTAINER_SCANNING_USE_USER_ID", "true");
 
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
         NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -30,6 +29,7 @@ public class ScannerTest
         String imageName = "songlongtj/alpine";
         String imageTag = "3.6";
         String nvScannerImage = "neuvector/scanner:latest";
+        //Replace by your own credentials
         String nvRegistryUser = "xxx";
         String nvRegistryPassword = "xxx";
         String nvRegistryURL = "https://registry.hub.docker.com";
@@ -39,22 +39,18 @@ public class ScannerTest
 
         ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
 
-        File file = new File(mountPath + "/scan_result.json");
-        Path path = Paths.get(mountPath + "/scan_result.json");
-
-        if(file.exists()){
+        if(scanReportData.getError_message().isEmpty()){
+            File file = new File(mountPath + "/scan_result.json");
+            Path path = Paths.get(mountPath + "/scan_result.json");
             FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
                     FileOwnerAttributeView.class);
             UserPrincipal user = fileOwner.getOwner();
-            InetAddress addr = InetAddress.getLocalHost();;
-            String hostname = addr.getHostName();
-            assertTrue( !hostname.contains("root" ));
-            assertTrue( hostname.contains(user.getName()) );
-            assertTrue( file.canWrite() );
-            assertTrue( file.canRead() );
-        }
 
-        assertTrue( scanReportData != null );
+            assertTrue(!user.getName().equals("root"));
+            assertTrue(file.canWrite());
+            assertTrue(file.canRead());
+        }
+        assertTrue(scanReportData != null);
     }
 
     @Test
@@ -68,27 +64,26 @@ public class ScannerTest
         String repositoryTag = "3.6";
         String nvScannerImage = "neuvector/scanner:latest";
         String nvRegistryURL = registryURL;
-        String nvRegistryUser = "";
-        String nvRegistryPassword = "";
+        //Replace by your own credentials
+        String nvRegistryUser = "xxx";
+        String nvRegistryPassword = "xxx";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
         NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
 
         ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
+        if(scanReportData.getError_message().isEmpty()) {
+            File file = new File(mountPath + "/scan_result.json");
+            Path path = Paths.get(mountPath + "/scan_result.json");
+            FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
+                    FileOwnerAttributeView.class);
+            UserPrincipal user = fileOwner.getOwner();
 
-        File file = new File(mountPath + "/scan_result.json");
-        Path path = Paths.get(mountPath + "/scan_result.json");
-        FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
-                FileOwnerAttributeView.class);
-        UserPrincipal user = fileOwner.getOwner();
-        InetAddress addr = InetAddress.getLocalHost();;
-        String hostname = addr.getHostName();
-
-        assertTrue( !hostname.contains("root" ));
-        assertTrue( hostname.contains(user.getName()) );
-        assertTrue( file.exists() );
-        assertTrue( file.canWrite() );
-        assertTrue( file.canRead() );
-        assertTrue( scanReportData != null );
+            assertTrue(!user.getName().equals("root"));
+            assertTrue(file.exists());
+            assertTrue(file.canWrite());
+            assertTrue(file.canRead());
+        }
+        assertTrue(scanReportData != null);
     }
 }

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -42,7 +42,7 @@ public class ScannerTest
         File file = new File(mountPath + "/scan_result.json");
         UserPrincipal user = getUserPrincipal(mountPath, file);
 
-        assertTrue(user.getName().equals("root") || user.getName().contains(System.getProperty("user.name")));
+        assertTrue(!user.getName().equals("root") );
         assertTrue( scanReportData != null );
     }
 
@@ -69,7 +69,7 @@ public class ScannerTest
         File file = new File(mountPath + "/scan_result.json");
         UserPrincipal user = getUserPrincipal(mountPath, file);
 
-        assertTrue(user.getName().equals("root") || user.getName().contains(System.getProperty("user.name")));
+        assertTrue(!user.getName().equals("root") );
         assertTrue( scanReportData != null );
     }
 

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -39,8 +39,7 @@ public class ScannerTest
         FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
                 FileOwnerAttributeView.class);
         UserPrincipal user = fileOwner.getOwner();
-        InetAddress addr;
-        addr = InetAddress.getLocalHost();
+        InetAddress addr = InetAddress.getLocalHost();;
         String hostname = addr.getHostName();
 
         Image image = new Image(imageName, imageTag);
@@ -75,8 +74,7 @@ public class ScannerTest
         FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
                 FileOwnerAttributeView.class);
         UserPrincipal user = fileOwner.getOwner();
-        InetAddress addr;
-        addr = InetAddress.getLocalHost();
+        InetAddress addr = InetAddress.getLocalHost();;
         String hostname = addr.getHostName();
 
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -7,8 +7,9 @@ import com.neuvector.model.Image;
 import com.neuvector.model.NVScanner;
 import com.neuvector.model.Registry;
 import com.neuvector.model.ScanRepoReportData;
-
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -22,6 +23,9 @@ import java.nio.file.attribute.UserPrincipal;
  */
 public class ScannerTest 
 {
+    @Rule
+    public TemporaryFolder mountFolder= new TemporaryFolder();
+
     @Test
     public void scanLocalImageTest() throws IOException {
         String license = "";
@@ -32,7 +36,8 @@ public class ScannerTest
         String nvRegistryUser = "";
         String nvRegistryPassword = "";
         String nvRegistryURL = "https://registry.hub.docker.com";
-        String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        String mountPath = mountFolder.getRoot().getAbsolutePath();
 
         Image image = new Image(imageName, imageTag);
         NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, true);
@@ -58,7 +63,8 @@ public class ScannerTest
         String nvRegistryURL = registryURL;
         String nvRegistryUser = "";
         String nvRegistryPassword = "";
-        String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        String mountPath = mountFolder.getRoot().getAbsolutePath();
 
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
         NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, true);

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -26,31 +26,24 @@ public class ScannerTest
     public void scanLocalImageTest() throws IOException {
         String license = "r+wzvemF4mHMIBkvKHXTuuLzw4ML/RW2ARfbC06Qem1VdQ8DXcMWNKbd8GD0uYiLoS9d9XPM8bff4ag66fqwdOa42oNXk9dzP1TTRg0zvVKJNMxbxKAuGMY24x0NlXstc3Jl2BcXq7aTHrlQwzJ/7qD8157+YfcjKJbywbt3WvvdpuoJtJIuKaO9hOfGu9/zbRZznEtZiJj56xaRMVZ/ZkPHIMseRWML7FUr1oft20PYU7ltf1BGPT/LlocAXAJucBpUz5iosRzS1iYJhU4M1kdBhEwQHl6FZXrtzJGYpM21587FyYrkvoIPQNlIijaAOiCXR060PJNfcQzOzEpYRidhVPnHIHQuIn8gcYuU3XwPB9Pq3tGzERpr0aB64EjSSanpcIh/XEhnXijiRP6CfxsHx8RvD/jkXy5VlJpTVFh1Iu7ywE6fePHb3hIe16uCtdYB8fu2p8ksCcnxXbjBUkKvdLLxq5gvOCfCJxknd4GdIS3UJySNblgmlfU6liYcgt555TitN5DAjuMhTaoxj9FoPPwJsl4rrf2+32cqUFI+9+UdNsSd2gWtS/8T2ifPHNVMA7fdPdIWx+/4jXP8u484cLqGG9RutNGPo0k7cmxmgx29FvVOMvpkotD8IZsbCfl8sFHtFRP7PegWYPghZf6yUkw5m4SD+bacVZalnLizZKbDgFuzPmH1LgrroVN1Ngf06JVfO6lDodbAOactsJC7P8DOPRUoOtnCf3ffgshPh+QSTKDOmNvFU51VB7MoLlZiKNaVP6yMqS1bUwxRpI5eehqhqCHy46PWfRHF2EnbiQOyYIjJSY5jE54TzOaKZ613GgdIaMN+mbXg+UWajDevwCvKQo+CrwpBoX72tP/as9G3zIJILaKuXbQRvTtZbgGREMSoLIDxPBYe3FVqMHFg/jUE9iPbsF16JHv/z3EzcAYKwYSyDEyVppTvLjQY0t/Vul4SEj+QWpyW7elAUmatzHdAcX2SB3oDOhUtDyIxw8rtenD9hCOfspJtEFknhtM+Zm1WuoQYRM5/paEVvbHZnu2XHY2cnBtxJZAD8wKktnSPGg3foCXQpQcSEyhfWhVT14WX2/GxgbdwIuxSBcoHlcduca5tKtlKAhJ4kjPPZeQc5A18z48pLRU=";
 
-        String imageName = "songlongtj/alpine";
+        String imageName = "alpine";
         String imageTag = "3.6";
         String nvScannerImage = "neuvector/scanner:latest";
-        //Replace by your own credentials
-        String nvRegistryUser = "xxx";
-        String nvRegistryPassword = "xxx";
+        String nvRegistryUser = "";
+        String nvRegistryPassword = "";
         String nvRegistryURL = "https://registry.hub.docker.com";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+
         Image image = new Image(imageName, imageTag);
         NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
 
         ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
 
-        if(scanReportData.getError_message().isEmpty()){
-            File file = new File(mountPath + "/scan_result.json");
-            Path path = Paths.get(mountPath + "/scan_result.json");
-            FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
-                    FileOwnerAttributeView.class);
-            UserPrincipal user = fileOwner.getOwner();
+        File file = new File(mountPath + "/scan_result.json");
+        UserPrincipal user = getUserPrincipal(mountPath, file);
 
-            assertTrue(!user.getName().equals("root"));
-            assertTrue(file.canWrite());
-            assertTrue(file.canRead());
-        }
-        assertTrue(scanReportData != null);
+        assertTrue(!user.getName().equals("root") || !user.getName().contains(System.getProperty("user.name")));
+        assertTrue( scanReportData != null );
     }
 
     @Test
@@ -64,26 +57,95 @@ public class ScannerTest
         String repositoryTag = "3.6";
         String nvScannerImage = "neuvector/scanner:latest";
         String nvRegistryURL = registryURL;
-        //Replace by your own credentials
-        String nvRegistryUser = "xxx";
-        String nvRegistryPassword = "xxx";
+        String nvRegistryUser = "";
+        String nvRegistryPassword = "";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
         NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
 
         ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
-        if(scanReportData.getError_message().isEmpty()) {
-            File file = new File(mountPath + "/scan_result.json");
+
+        File file = new File(mountPath + "/scan_result.json");
+        UserPrincipal user = getUserPrincipal(mountPath, file);
+
+        assertTrue(!user.getName().equals("root") || !user.getName().contains(System.getProperty("user.name")));
+        assertTrue( scanReportData != null );
+    }
+
+    @Test
+    public void scanRegistryTestWhenFileIsCreatedByNoRootUser() throws IOException {
+        String license = "r+wzvemF4mHMIBkvKHXTuuLzw4ML/RW2ARfbC06Qem1VdQ8DXcMWNKbd8GD0uYiLoS9d9XPM8bff4ag66fqwdOa42oNXk9dzP1TTRg0zvVKJNMxbxKAuGMY24x0NlXstc3Jl2BcXq7aTHrlQwzJ/7qD8157+YfcjKJbywbt3WvvdpuoJtJIuKaO9hOfGu9/zbRZznEtZiJj56xaRMVZ/ZkPHIMseRWML7FUr1oft20PYU7ltf1BGPT/LlocAXAJucBpUz5iosRzS1iYJhU4M1kdBhEwQHl6FZXrtzJGYpM21587FyYrkvoIPQNlIijaAOiCXR060PJNfcQzOzEpYRidhVPnHIHQuIn8gcYuU3XwPB9Pq3tGzERpr0aB64EjSSanpcIh/XEhnXijiRP6CfxsHx8RvD/jkXy5VlJpTVFh1Iu7ywE6fePHb3hIe16uCtdYB8fu2p8ksCcnxXbjBUkKvdLLxq5gvOCfCJxknd4GdIS3UJySNblgmlfU6liYcgt555TitN5DAjuMhTaoxj9FoPPwJsl4rrf2+32cqUFI+9+UdNsSd2gWtS/8T2ifPHNVMA7fdPdIWx+/4jXP8u484cLqGG9RutNGPo0k7cmxmgx29FvVOMvpkotD8IZsbCfl8sFHtFRP7PegWYPghZf6yUkw5m4SD+bacVZalnLizZKbDgFuzPmH1LgrroVN1Ngf06JVfO6lDodbAOactsJC7P8DOPRUoOtnCf3ffgshPh+QSTKDOmNvFU51VB7MoLlZiKNaVP6yMqS1bUwxRpI5eehqhqCHy46PWfRHF2EnbiQOyYIjJSY5jE54TzOaKZ613GgdIaMN+mbXg+UWajDevwCvKQo+CrwpBoX72tP/as9G3zIJILaKuXbQRvTtZbgGREMSoLIDxPBYe3FVqMHFg/jUE9iPbsF16JHv/z3EzcAYKwYSyDEyVppTvLjQY0t/Vul4SEj+QWpyW7elAUmatzHdAcX2SB3oDOhUtDyIxw8rtenD9hCOfspJtEFknhtM+Zm1WuoQYRM5/paEVvbHZnu2XHY2cnBtxJZAD8wKktnSPGg3foCXQpQcSEyhfWhVT14WX2/GxgbdwIuxSBcoHlcduca5tKtlKAhJ4kjPPZeQc5A18z48pLRU=";
+
+        String registryURL = "https://registry.hub.docker.com";
+        String regUser = "";
+        String regPassword = "";
+        String repository = "library/alpine";
+        String repositoryTag = "3.6";
+        String nvScannerImage = "neuvector/scanner:latest";
+        String nvRegistryURL = registryURL;
+        //Replace by your own credentials
+        String nvRegistryUser = "";
+        String nvRegistryPassword = "";
+        String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
+
+        File file = new File(mountPath + "/scan_result.json");
+        //Delete the file to verify after that the file was created with a user different of root
+        UserPrincipal user = getUserPrincipal(mountPath, file);
+        if (user != null && !user.getName().equals("root")) {
+            file.delete();
+        }
+        ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
+
+        //Get the user after the file creation
+        user = getUserPrincipal(mountPath, file);
+        //after this the file must exist, even if an error happened the file is created with the error as info.
+        assertTrue(file.exists());
+        assertTrue(!user.getName().equals("root") );
+        assertTrue(scanReportData != null);
+    }
+
+    @Test
+    public void scanLocalImageTestWhenFileIsCreatedByNoRootUser() throws IOException {
+        String license = "r+wzvemF4mHMIBkvKHXTuuLzw4ML/RW2ARfbC06Qem1VdQ8DXcMWNKbd8GD0uYiLoS9d9XPM8bff4ag66fqwdOa42oNXk9dzP1TTRg0zvVKJNMxbxKAuGMY24x0NlXstc3Jl2BcXq7aTHrlQwzJ/7qD8157+YfcjKJbywbt3WvvdpuoJtJIuKaO9hOfGu9/zbRZznEtZiJj56xaRMVZ/ZkPHIMseRWML7FUr1oft20PYU7ltf1BGPT/LlocAXAJucBpUz5iosRzS1iYJhU4M1kdBhEwQHl6FZXrtzJGYpM21587FyYrkvoIPQNlIijaAOiCXR060PJNfcQzOzEpYRidhVPnHIHQuIn8gcYuU3XwPB9Pq3tGzERpr0aB64EjSSanpcIh/XEhnXijiRP6CfxsHx8RvD/jkXy5VlJpTVFh1Iu7ywE6fePHb3hIe16uCtdYB8fu2p8ksCcnxXbjBUkKvdLLxq5gvOCfCJxknd4GdIS3UJySNblgmlfU6liYcgt555TitN5DAjuMhTaoxj9FoPPwJsl4rrf2+32cqUFI+9+UdNsSd2gWtS/8T2ifPHNVMA7fdPdIWx+/4jXP8u484cLqGG9RutNGPo0k7cmxmgx29FvVOMvpkotD8IZsbCfl8sFHtFRP7PegWYPghZf6yUkw5m4SD+bacVZalnLizZKbDgFuzPmH1LgrroVN1Ngf06JVfO6lDodbAOactsJC7P8DOPRUoOtnCf3ffgshPh+QSTKDOmNvFU51VB7MoLlZiKNaVP6yMqS1bUwxRpI5eehqhqCHy46PWfRHF2EnbiQOyYIjJSY5jE54TzOaKZ613GgdIaMN+mbXg+UWajDevwCvKQo+CrwpBoX72tP/as9G3zIJILaKuXbQRvTtZbgGREMSoLIDxPBYe3FVqMHFg/jUE9iPbsF16JHv/z3EzcAYKwYSyDEyVppTvLjQY0t/Vul4SEj+QWpyW7elAUmatzHdAcX2SB3oDOhUtDyIxw8rtenD9hCOfspJtEFknhtM+Zm1WuoQYRM5/paEVvbHZnu2XHY2cnBtxJZAD8wKktnSPGg3foCXQpQcSEyhfWhVT14WX2/GxgbdwIuxSBcoHlcduca5tKtlKAhJ4kjPPZeQc5A18z48pLRU=";
+
+        String imageName = "songlongtj/alpine";
+        String imageTag = "3.6";
+        String nvScannerImage = "neuvector/scanner:latest";
+        String nvRegistryUser = "";
+        String nvRegistryPassword = "";
+        String nvRegistryURL = "https://registry.hub.docker.com";
+        String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+
+        Image image = new Image(imageName, imageTag);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
+
+        File file = new File(mountPath + "/scan_result.json");
+        //Delete the file if is not created by root, to verify after that the file was created with a user different of root
+        UserPrincipal user = getUserPrincipal(mountPath, file);
+        if (user != null && !user.getName().equals("root")) {
+            file.delete();
+        }
+        ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
+
+        //Get the user after the file creation
+        user = getUserPrincipal(mountPath, file);
+        //after this the file must exist, even if an error happened the file is created with the error as info.
+        assertTrue(file.exists());
+        assertTrue(!user.getName().equals("root") );
+        assertTrue(scanReportData != null);
+    }
+
+    private static UserPrincipal getUserPrincipal(String mountPath, File file) throws IOException {
+        UserPrincipal user = null;
+        if (file.exists()) {
             Path path = Paths.get(mountPath + "/scan_result.json");
             FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
                     FileOwnerAttributeView.class);
-            UserPrincipal user = fileOwner.getOwner();
-
-            assertTrue(!user.getName().equals("root"));
-            assertTrue(file.exists());
-            assertTrue(file.canWrite());
-            assertTrue(file.canRead());
+            user = fileOwner.getOwner();
         }
-        assertTrue(scanReportData != null);
+        return user;
     }
 }

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -7,9 +7,7 @@ import com.neuvector.model.NVScanner;
 import com.neuvector.model.Registry;
 import com.neuvector.model.ScanRepoReportData;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -23,9 +21,6 @@ import java.nio.file.attribute.UserPrincipal;
  */
 public class ScannerTest 
 {
-
-    @Rule
-    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
     @Test
     public void scanLocalImageTest() throws IOException {
         String license = "";
@@ -37,10 +32,9 @@ public class ScannerTest
         String nvRegistryPassword = "";
         String nvRegistryURL = "https://registry.hub.docker.com";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
-        environmentVariables.set("NEXUS_CONTAINER_SCANNING_USE_USER_ID", "true");
 
         Image image = new Image(imageName, imageTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, true);
 
         ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
 
@@ -64,10 +58,9 @@ public class ScannerTest
         String nvRegistryUser = "";
         String nvRegistryPassword = "";
         String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
-        environmentVariables.set("NEXUS_CONTAINER_SCANNING_USE_USER_ID", "true");
 
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, true);
 
         ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
 

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -24,7 +24,7 @@ public class ScannerTest
 {
     @Test
     public void scanLocalImageTest() throws IOException {
-        String license = "r+wzvemF4mHMIBkvKHXTuuLzw4ML/RW2ARfbC06Qem1VdQ8DXcMWNKbd8GD0uYiLoS9d9XPM8bff4ag66fqwdOa42oNXk9dzP1TTRg0zvVKJNMxbxKAuGMY24x0NlXstc3Jl2BcXq7aTHrlQwzJ/7qD8157+YfcjKJbywbt3WvvdpuoJtJIuKaO9hOfGu9/zbRZznEtZiJj56xaRMVZ/ZkPHIMseRWML7FUr1oft20PYU7ltf1BGPT/LlocAXAJucBpUz5iosRzS1iYJhU4M1kdBhEwQHl6FZXrtzJGYpM21587FyYrkvoIPQNlIijaAOiCXR060PJNfcQzOzEpYRidhVPnHIHQuIn8gcYuU3XwPB9Pq3tGzERpr0aB64EjSSanpcIh/XEhnXijiRP6CfxsHx8RvD/jkXy5VlJpTVFh1Iu7ywE6fePHb3hIe16uCtdYB8fu2p8ksCcnxXbjBUkKvdLLxq5gvOCfCJxknd4GdIS3UJySNblgmlfU6liYcgt555TitN5DAjuMhTaoxj9FoPPwJsl4rrf2+32cqUFI+9+UdNsSd2gWtS/8T2ifPHNVMA7fdPdIWx+/4jXP8u484cLqGG9RutNGPo0k7cmxmgx29FvVOMvpkotD8IZsbCfl8sFHtFRP7PegWYPghZf6yUkw5m4SD+bacVZalnLizZKbDgFuzPmH1LgrroVN1Ngf06JVfO6lDodbAOactsJC7P8DOPRUoOtnCf3ffgshPh+QSTKDOmNvFU51VB7MoLlZiKNaVP6yMqS1bUwxRpI5eehqhqCHy46PWfRHF2EnbiQOyYIjJSY5jE54TzOaKZ613GgdIaMN+mbXg+UWajDevwCvKQo+CrwpBoX72tP/as9G3zIJILaKuXbQRvTtZbgGREMSoLIDxPBYe3FVqMHFg/jUE9iPbsF16JHv/z3EzcAYKwYSyDEyVppTvLjQY0t/Vul4SEj+QWpyW7elAUmatzHdAcX2SB3oDOhUtDyIxw8rtenD9hCOfspJtEFknhtM+Zm1WuoQYRM5/paEVvbHZnu2XHY2cnBtxJZAD8wKktnSPGg3foCXQpQcSEyhfWhVT14WX2/GxgbdwIuxSBcoHlcduca5tKtlKAhJ4kjPPZeQc5A18z48pLRU=";
+        String license = "";
 
         String imageName = "alpine";
         String imageTag = "3.6";
@@ -42,13 +42,13 @@ public class ScannerTest
         File file = new File(mountPath + "/scan_result.json");
         UserPrincipal user = getUserPrincipal(mountPath, file);
 
-        assertTrue(!user.getName().equals("root") || !user.getName().contains(System.getProperty("user.name")));
+        assertTrue(user.getName().equals("root") || user.getName().contains(System.getProperty("user.name")));
         assertTrue( scanReportData != null );
     }
 
     @Test
     public void scanRegistryTest() throws IOException {
-        String license = "r+wzvemF4mHMIBkvKHXTuuLzw4ML/RW2ARfbC06Qem1VdQ8DXcMWNKbd8GD0uYiLoS9d9XPM8bff4ag66fqwdOa42oNXk9dzP1TTRg0zvVKJNMxbxKAuGMY24x0NlXstc3Jl2BcXq7aTHrlQwzJ/7qD8157+YfcjKJbywbt3WvvdpuoJtJIuKaO9hOfGu9/zbRZznEtZiJj56xaRMVZ/ZkPHIMseRWML7FUr1oft20PYU7ltf1BGPT/LlocAXAJucBpUz5iosRzS1iYJhU4M1kdBhEwQHl6FZXrtzJGYpM21587FyYrkvoIPQNlIijaAOiCXR060PJNfcQzOzEpYRidhVPnHIHQuIn8gcYuU3XwPB9Pq3tGzERpr0aB64EjSSanpcIh/XEhnXijiRP6CfxsHx8RvD/jkXy5VlJpTVFh1Iu7ywE6fePHb3hIe16uCtdYB8fu2p8ksCcnxXbjBUkKvdLLxq5gvOCfCJxknd4GdIS3UJySNblgmlfU6liYcgt555TitN5DAjuMhTaoxj9FoPPwJsl4rrf2+32cqUFI+9+UdNsSd2gWtS/8T2ifPHNVMA7fdPdIWx+/4jXP8u484cLqGG9RutNGPo0k7cmxmgx29FvVOMvpkotD8IZsbCfl8sFHtFRP7PegWYPghZf6yUkw5m4SD+bacVZalnLizZKbDgFuzPmH1LgrroVN1Ngf06JVfO6lDodbAOactsJC7P8DOPRUoOtnCf3ffgshPh+QSTKDOmNvFU51VB7MoLlZiKNaVP6yMqS1bUwxRpI5eehqhqCHy46PWfRHF2EnbiQOyYIjJSY5jE54TzOaKZ613GgdIaMN+mbXg+UWajDevwCvKQo+CrwpBoX72tP/as9G3zIJILaKuXbQRvTtZbgGREMSoLIDxPBYe3FVqMHFg/jUE9iPbsF16JHv/z3EzcAYKwYSyDEyVppTvLjQY0t/Vul4SEj+QWpyW7elAUmatzHdAcX2SB3oDOhUtDyIxw8rtenD9hCOfspJtEFknhtM+Zm1WuoQYRM5/paEVvbHZnu2XHY2cnBtxJZAD8wKktnSPGg3foCXQpQcSEyhfWhVT14WX2/GxgbdwIuxSBcoHlcduca5tKtlKAhJ4kjPPZeQc5A18z48pLRU=";
+        String license = "";
 
         String registryURL = "https://registry.hub.docker.com";
         String regUser = "";
@@ -69,73 +69,8 @@ public class ScannerTest
         File file = new File(mountPath + "/scan_result.json");
         UserPrincipal user = getUserPrincipal(mountPath, file);
 
-        assertTrue(!user.getName().equals("root") || !user.getName().contains(System.getProperty("user.name")));
+        assertTrue(user.getName().equals("root") || user.getName().contains(System.getProperty("user.name")));
         assertTrue( scanReportData != null );
-    }
-
-    @Test
-    public void scanRegistryTestWhenFileIsCreatedByNoRootUser() throws IOException {
-        String license = "r+wzvemF4mHMIBkvKHXTuuLzw4ML/RW2ARfbC06Qem1VdQ8DXcMWNKbd8GD0uYiLoS9d9XPM8bff4ag66fqwdOa42oNXk9dzP1TTRg0zvVKJNMxbxKAuGMY24x0NlXstc3Jl2BcXq7aTHrlQwzJ/7qD8157+YfcjKJbywbt3WvvdpuoJtJIuKaO9hOfGu9/zbRZznEtZiJj56xaRMVZ/ZkPHIMseRWML7FUr1oft20PYU7ltf1BGPT/LlocAXAJucBpUz5iosRzS1iYJhU4M1kdBhEwQHl6FZXrtzJGYpM21587FyYrkvoIPQNlIijaAOiCXR060PJNfcQzOzEpYRidhVPnHIHQuIn8gcYuU3XwPB9Pq3tGzERpr0aB64EjSSanpcIh/XEhnXijiRP6CfxsHx8RvD/jkXy5VlJpTVFh1Iu7ywE6fePHb3hIe16uCtdYB8fu2p8ksCcnxXbjBUkKvdLLxq5gvOCfCJxknd4GdIS3UJySNblgmlfU6liYcgt555TitN5DAjuMhTaoxj9FoPPwJsl4rrf2+32cqUFI+9+UdNsSd2gWtS/8T2ifPHNVMA7fdPdIWx+/4jXP8u484cLqGG9RutNGPo0k7cmxmgx29FvVOMvpkotD8IZsbCfl8sFHtFRP7PegWYPghZf6yUkw5m4SD+bacVZalnLizZKbDgFuzPmH1LgrroVN1Ngf06JVfO6lDodbAOactsJC7P8DOPRUoOtnCf3ffgshPh+QSTKDOmNvFU51VB7MoLlZiKNaVP6yMqS1bUwxRpI5eehqhqCHy46PWfRHF2EnbiQOyYIjJSY5jE54TzOaKZ613GgdIaMN+mbXg+UWajDevwCvKQo+CrwpBoX72tP/as9G3zIJILaKuXbQRvTtZbgGREMSoLIDxPBYe3FVqMHFg/jUE9iPbsF16JHv/z3EzcAYKwYSyDEyVppTvLjQY0t/Vul4SEj+QWpyW7elAUmatzHdAcX2SB3oDOhUtDyIxw8rtenD9hCOfspJtEFknhtM+Zm1WuoQYRM5/paEVvbHZnu2XHY2cnBtxJZAD8wKktnSPGg3foCXQpQcSEyhfWhVT14WX2/GxgbdwIuxSBcoHlcduca5tKtlKAhJ4kjPPZeQc5A18z48pLRU=";
-
-        String registryURL = "https://registry.hub.docker.com";
-        String regUser = "";
-        String regPassword = "";
-        String repository = "library/alpine";
-        String repositoryTag = "3.6";
-        String nvScannerImage = "neuvector/scanner:latest";
-        String nvRegistryURL = registryURL;
-        //Replace by your own credentials
-        String nvRegistryUser = "";
-        String nvRegistryPassword = "";
-        String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
-        Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
-
-        File file = new File(mountPath + "/scan_result.json");
-        //Delete the file to verify after that the file was created with a user different of root
-        UserPrincipal user = getUserPrincipal(mountPath, file);
-        if (user != null && !user.getName().equals("root")) {
-            file.delete();
-        }
-        ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
-
-        //Get the user after the file creation
-        user = getUserPrincipal(mountPath, file);
-        //after this the file must exist, even if an error happened the file is created with the error as info.
-        assertTrue(file.exists());
-        assertTrue(!user.getName().equals("root") );
-        assertTrue(scanReportData != null);
-    }
-
-    @Test
-    public void scanLocalImageTestWhenFileIsCreatedByNoRootUser() throws IOException {
-        String license = "r+wzvemF4mHMIBkvKHXTuuLzw4ML/RW2ARfbC06Qem1VdQ8DXcMWNKbd8GD0uYiLoS9d9XPM8bff4ag66fqwdOa42oNXk9dzP1TTRg0zvVKJNMxbxKAuGMY24x0NlXstc3Jl2BcXq7aTHrlQwzJ/7qD8157+YfcjKJbywbt3WvvdpuoJtJIuKaO9hOfGu9/zbRZznEtZiJj56xaRMVZ/ZkPHIMseRWML7FUr1oft20PYU7ltf1BGPT/LlocAXAJucBpUz5iosRzS1iYJhU4M1kdBhEwQHl6FZXrtzJGYpM21587FyYrkvoIPQNlIijaAOiCXR060PJNfcQzOzEpYRidhVPnHIHQuIn8gcYuU3XwPB9Pq3tGzERpr0aB64EjSSanpcIh/XEhnXijiRP6CfxsHx8RvD/jkXy5VlJpTVFh1Iu7ywE6fePHb3hIe16uCtdYB8fu2p8ksCcnxXbjBUkKvdLLxq5gvOCfCJxknd4GdIS3UJySNblgmlfU6liYcgt555TitN5DAjuMhTaoxj9FoPPwJsl4rrf2+32cqUFI+9+UdNsSd2gWtS/8T2ifPHNVMA7fdPdIWx+/4jXP8u484cLqGG9RutNGPo0k7cmxmgx29FvVOMvpkotD8IZsbCfl8sFHtFRP7PegWYPghZf6yUkw5m4SD+bacVZalnLizZKbDgFuzPmH1LgrroVN1Ngf06JVfO6lDodbAOactsJC7P8DOPRUoOtnCf3ffgshPh+QSTKDOmNvFU51VB7MoLlZiKNaVP6yMqS1bUwxRpI5eehqhqCHy46PWfRHF2EnbiQOyYIjJSY5jE54TzOaKZ613GgdIaMN+mbXg+UWajDevwCvKQo+CrwpBoX72tP/as9G3zIJILaKuXbQRvTtZbgGREMSoLIDxPBYe3FVqMHFg/jUE9iPbsF16JHv/z3EzcAYKwYSyDEyVppTvLjQY0t/Vul4SEj+QWpyW7elAUmatzHdAcX2SB3oDOhUtDyIxw8rtenD9hCOfspJtEFknhtM+Zm1WuoQYRM5/paEVvbHZnu2XHY2cnBtxJZAD8wKktnSPGg3foCXQpQcSEyhfWhVT14WX2/GxgbdwIuxSBcoHlcduca5tKtlKAhJ4kjPPZeQc5A18z48pLRU=";
-
-        String imageName = "songlongtj/alpine";
-        String imageTag = "3.6";
-        String nvScannerImage = "neuvector/scanner:latest";
-        String nvRegistryUser = "";
-        String nvRegistryPassword = "";
-        String nvRegistryURL = "https://registry.hub.docker.com";
-        String mountPath = "/temp";  //mountPath is an optional parameter. It will use "/var/neuvector" by default.
-
-        Image image = new Image(imageName, imageTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
-
-        File file = new File(mountPath + "/scan_result.json");
-        //Delete the file if is not created by root, to verify after that the file was created with a user different of root
-        UserPrincipal user = getUserPrincipal(mountPath, file);
-        if (user != null && !user.getName().equals("root")) {
-            file.delete();
-        }
-        ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
-
-        //Get the user after the file creation
-        user = getUserPrincipal(mountPath, file);
-        //after this the file must exist, even if an error happened the file is created with the error as info.
-        assertTrue(file.exists());
-        assertTrue(!user.getName().equals("root") );
-        assertTrue(scanReportData != null);
     }
 
     private static UserPrincipal getUserPrincipal(String mountPath, File file) throws IOException {

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -39,8 +39,7 @@ public class ScannerTest
 
         ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
 
-        File file = new File(mountPath + "/scan_result.json");
-        UserPrincipal user = getUserPrincipal(mountPath, file);
+        UserPrincipal user = getUserPrincipal(mountPath);
 
         assertTrue(!user.getName().equals("root") );
         assertTrue( scanReportData != null );
@@ -66,14 +65,13 @@ public class ScannerTest
 
         ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
 
-        File file = new File(mountPath + "/scan_result.json");
-        UserPrincipal user = getUserPrincipal(mountPath, file);
+        UserPrincipal user = getUserPrincipal(mountPath);
 
         assertTrue(!user.getName().equals("root") );
         assertTrue( scanReportData != null );
     }
 
-    private static UserPrincipal getUserPrincipal(String mountPath, File file) throws IOException {
+    private static UserPrincipal getUserPrincipal(String mountPath) throws IOException {
         UserPrincipal user = null;
         Path path = Paths.get(mountPath + "/scan_result.json");
         FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,


### PR DESCRIPTION
Jira ticket: https://issues.sonatype.org/browse/CLM-24219

Run the nexus-iq-cli docker image with the -u option, to avoid using root user inside the container. This is important because nexus-iq-cli writes files in the volumes, and if it's run as root (by default a container runs as root if not explicitly configured otherwise) it leaves files owned by root in my reports and tmp folders.

**Testing**

Check the test steps on the Jira ticket
- 
- For Linux users, for local images scanining we need to execute the next command before running a scanning, in order to avoid getting errors:  sudo chown {user}:docker /var/run/docker.sock [link error](https://issues.sonatype.org/browse/CLM-24219#:~:text=sudo%20chown%20%5Buser%5D%3Adocker%20/var/run/docker.sock])