### PR TITLE
CLM-28352 - Container scan of SE linux enabled image does not work 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ add scanner.jar to your classpath.
     //The path to keep the scan report. 
     //When run it in Jenkins plugin, you can use the project's build path as the mountPath
     String mountPath = "/temp"; 
-    
     // If you don't assign a value to it, it will use the default path "/var/neuvector" to save the scan report.
-    // NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword)
-    com.neuvector.model.NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath);
+    
+    boolean bindMountShared = null|true|false; //value in true, indicates that the bind mount content is shared among multiple containers
+    
+    // NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, log, bindMountShared)
+    com.neuvector.model.NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, bindMountShared);
 
     //NeuVector license to run the Scanner
     String license = "xxx";  
@@ -83,8 +85,9 @@ add scanner.jar to your classpath.
     String nvRegUser = "";
     String nvPassword = "";
     String mountPath = "/temp"; //The path to keep the scan report. If you don't assign a value to it, it will use the path "/var/neuvector" by default.
-
-    com.neuvector.model.NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryUrl, nvRegUser, nvPassword, mountPath);
+    boolean bindMountShared = null|true|false; //value in true, indicates that the bind mount content is shared among multiple containers
+    
+    com.neuvector.model.NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryUrl, nvRegUser, nvPassword, mountPath, bindMountShared);
 
     // The scan result will be returned as a java bean object
     com.neuvector.model.ScanRepoReportData scanReportData = com.neuvector.Scanner.scanRegistry(registry, scanner, license);

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.neuvector</groupId>
   <artifactId>scanner</artifactId>
-  <version>1.10</version>
+  <version>1.11</version>
   <packaging>jar</packaging>
 
   <name>NeuVector Scanner API</name>

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -65,7 +65,7 @@ public class Scanner
                 .withUserAndGroup(getDockerUserGroupCmdArg(getScanReportPath(nvScanner.getNvMountPath())))
                 .withName(generateScannerName())
                 .withVolume(Scanner.SOCKET_MAPPING)
-                .withVolume(appendSELinuxSuffixIfRequired(nvScanner.isBindMountShared(), getMountPath(nvScanner)))
+                .withVolume(appendBindMountSharedSuffixIfRequired(nvScanner.isBindMountShared(), getMountPath(nvScanner)))
                 .withEnvironment("SCANNER_REPOSITORY=" + registry.getRepository())
                 .withEnvironment("SCANNER_TAG=" + registry.getRepositoryTag())
                 .withEnvironment("SCANNER_LICENSE=" + license)
@@ -128,7 +128,7 @@ public class Scanner
                 .withUserAndGroup(getDockerUserGroupCmdArg(getScanReportPath(nvScanner.getNvMountPath())))
                 .withName(generateScannerName())
                 .withVolume(Scanner.SOCKET_MAPPING)
-                .withVolume(getMountPath(nvScanner))
+                .withVolume(appendBindMountSharedSuffixIfRequired(nvScanner.isBindMountShared(), getMountPath(nvScanner)))
                 .withEnvironment("SCANNER_REPOSITORY=" + image.getImageName())
                 .withEnvironment("SCANNER_TAG=" + image.getImageTag())
                 .withEnvironment("SCANNER_LICENSE=" + license)
@@ -322,8 +322,8 @@ public class Scanner
         return mountPath;
     }
 
-    private static String appendSELinuxSuffixIfRequired(final Boolean isSELinuxSuffixRequired, final String mountPath) {
-        if(isSELinuxSuffixRequired != null && isSELinuxSuffixRequired){
+    private static String appendBindMountSharedSuffixIfRequired(final Boolean isBindMountShared, final String mountPath) {
+        if(isBindMountShared != null && isBindMountShared){
             return new StringBuilder(mountPath).append(":z").toString();
         }
 

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -329,7 +329,7 @@ public class Scanner
         if(isBindMountShared != null && isBindMountShared){
             updatedMountPath = new StringBuilder(mountPath).append(":z").toString();
         }
-        log.debug(updatedMountPath);
+        log.info("Mount path used: {}", updatedMountPath);
         return updatedMountPath;
     }
 

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -65,7 +65,7 @@ public class Scanner
                 .withUserAndGroup(getDockerUserGroupCmdArg(getScanReportPath(nvScanner.getNvMountPath())))
                 .withName(generateScannerName())
                 .withVolume(Scanner.SOCKET_MAPPING)
-                .withVolume(getMountPath(nvScanner))
+                .withVolume(appendSELinuxSuffixIfRequired(nvScanner.isSELinuxSuffixRequired(), getMountPath(nvScanner)))
                 .withEnvironment("SCANNER_REPOSITORY=" + registry.getRepository())
                 .withEnvironment("SCANNER_TAG=" + registry.getRepositoryTag())
                 .withEnvironment("SCANNER_LICENSE=" + license)
@@ -319,6 +319,14 @@ public class Scanner
         }else {
             mountPath = CONTAINER_PATH + mountPath;
         }
+        return mountPath;
+    }
+
+    private static String appendSELinuxSuffixIfRequired(final Boolean isSELinuxSuffixRequired, final String mountPath) {
+        if(isSELinuxSuffixRequired != null && isSELinuxSuffixRequired){
+            return new StringBuilder(mountPath).append(":z").toString();
+        }
+
         return mountPath;
     }
 

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -65,7 +65,7 @@ public class Scanner
                 .withUserAndGroup(getDockerUserGroupCmdArg(getScanReportPath(nvScanner.getNvMountPath())))
                 .withName(generateScannerName())
                 .withVolume(Scanner.SOCKET_MAPPING)
-                .withVolume(appendSELinuxSuffixIfRequired(nvScanner.isSELinuxSuffixRequired(), getMountPath(nvScanner)))
+                .withVolume(appendSELinuxSuffixIfRequired(nvScanner.isBindMountShared(), getMountPath(nvScanner)))
                 .withEnvironment("SCANNER_REPOSITORY=" + registry.getRepository())
                 .withEnvironment("SCANNER_TAG=" + registry.getRepositoryTag())
                 .withEnvironment("SCANNER_LICENSE=" + license)

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -329,7 +329,7 @@ public class Scanner
         if(isBindMountShared != null && isBindMountShared){
             updatedMountPath = new StringBuilder(mountPath).append(":z").toString();
         }
-        log.info("Mount path used: {}", updatedMountPath);
+        log.info("Using volume binding: {}", updatedMountPath);
         return updatedMountPath;
     }
 

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -49,6 +49,7 @@ public class Scanner
     public static ScanRepoReportData scanRegistry(Registry registry, NVScanner nvScanner, String license, Boolean scanLayers) {
 
         String errorMessage = "";
+        Logger log = nvScanner.getLog();
         if(registry == null || nvScanner == null){
             errorMessage = "The Registry and nvScanner can't be null.";
         } else {
@@ -80,6 +81,7 @@ public class Scanner
                     .withEnvironment("SCANNER_REGISTRY_PASSWORD=" + registry.getLoginPassword());
             }
             String[] cmdArgs = builder.buildForImage(getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL()));
+            log.debug(getVolumeArgs(cmdArgs));
             String[] credentials = {registry.getLoginPassword(), license};
             reportData = runScan(cmdArgs, nvScanner, credentials);
         }
@@ -111,6 +113,7 @@ public class Scanner
     public static ScanRepoReportData scanLocalImage(Image image, NVScanner nvScanner, String license, Boolean scanLayers) {
 
         String errorMessage = "";
+        Logger log = nvScanner.getLog();
         if(image == null || nvScanner == null){
             errorMessage = "The image and nvScanner can't be null.";
         } else {
@@ -137,6 +140,7 @@ public class Scanner
                 builder.withEnvironment("SCANNER_SCAN_LAYERS=true");
             }
             String[] cmdArgs = builder.buildForImage(getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL()));
+            log.debug(getVolumeArgs(cmdArgs));
             reportData = runScan(cmdArgs, nvScanner, credentials);
         }
 
@@ -431,6 +435,18 @@ public class Scanner
             user = fileOwner.getOwner();
         }
         return user;
+    }
+
+    private static String getVolumeArgs(final String[] cmdArgs) {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < cmdArgs.length; i++) {
+            if (cmdArgs[i] == "-v" && i + 1 < cmdArgs.length) {
+                sb.append(cmdArgs[i]).append(" ");
+                sb.append(cmdArgs[i + 1]).append(" ");
+            }
+        }
+        return sb.toString();
     }
 
     public static String deleteDockerImagesByLabelKey(String label) {

--- a/src/main/java/com/neuvector/model/NVScanner.java
+++ b/src/main/java/com/neuvector/model/NVScanner.java
@@ -9,6 +9,7 @@ public class NVScanner {
     String nvRegistryPassword;
     String nvMountPath;
     Logger log;
+    Boolean isSELinuxSuffixRequired;
 
     public NVScanner(){}
 
@@ -18,12 +19,13 @@ public class NVScanner {
      * @param nvRegistryUser  The user name to login the registry. If the user name and the password are empty, the API will skip the docker login action.
      * @param nvRegistryPassword The password to login the registry.
      */
-    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, Logger log){
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, Logger log, Boolean isSELinuxSuffixRequired){
         this.nvRegistryURL = nvRegistryURL;
         this.nvScannerImage = nvScannerImage;
         this.nvRegistryUser = nvRegistryUser;
         this.nvRegistryPassword = nvRegistryPassword;
-        this.log = log;        
+        this.log = log;
+        this.isSELinuxSuffixRequired = isSELinuxSuffixRequired;
     }
 
     /**
@@ -34,13 +36,14 @@ public class NVScanner {
      * @param nvRegistryPassword The password to login the registry.
      * @param nvMountPath  The mount path mapping to the path inside the NeuVector Scanner container. It is the path to store the scan result. It is optional. If you don't pass in <code>nvMountPath</code>, it will use the default path "/var/neuvector"
      */
-    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Logger log){
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Logger log , Boolean isSELinuxSuffixRequired){
         this.nvRegistryURL = nvRegistryURL;
         this.nvScannerImage = nvScannerImage;
         this.nvRegistryUser = nvRegistryUser;
         this.nvRegistryPassword = nvRegistryPassword;
         this.nvMountPath = nvMountPath;
         this.log = log;
+        this.isSELinuxSuffixRequired = isSELinuxSuffixRequired;
     }
 
     /**
@@ -115,5 +118,9 @@ public class NVScanner {
     
     public Logger getLog() {
         return log;
-    }    
+    }
+
+    public Boolean isSELinuxSuffixRequired() {
+        return isSELinuxSuffixRequired;
+    }
 }

--- a/src/main/java/com/neuvector/model/NVScanner.java
+++ b/src/main/java/com/neuvector/model/NVScanner.java
@@ -18,6 +18,7 @@ public class NVScanner {
      * @param nvRegistryURL  The registry from which to pull the NeuVector Scanner image. If it is empty, the API will skip the action to pull the NeuVector Scanner image.
      * @param nvRegistryUser  The user name to login the registry. If the user name and the password are empty, the API will skip the docker login action.
      * @param nvRegistryPassword The password to login the registry.
+     * @param bindMountShared Indicates whether the bind mount content needs to be shared. Using True when it's needed. If null is received, the default value, which is False, will be used.
      */
     public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, Logger log, Boolean bindMountShared){
         this.nvRegistryURL = nvRegistryURL;
@@ -35,6 +36,7 @@ public class NVScanner {
      * @param nvRegistryUser  The user name to login the registry. If the user name and the password are empty, the API will skip the docker login action.
      * @param nvRegistryPassword The password to login the registry.
      * @param nvMountPath  The mount path mapping to the path inside the NeuVector Scanner container. It is the path to store the scan result. It is optional. If you don't pass in <code>nvMountPath</code>, it will use the default path "/var/neuvector"
+     * @param bindMountShared Indicates whether the bind mount content needs to be shared. Using True when it's needed. If null is received, the default value, which is False, will be used.
      */
     public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Logger log, Boolean bindMountShared){
         this.nvRegistryURL = nvRegistryURL;

--- a/src/main/java/com/neuvector/model/NVScanner.java
+++ b/src/main/java/com/neuvector/model/NVScanner.java
@@ -9,7 +9,7 @@ public class NVScanner {
     String nvRegistryPassword;
     String nvMountPath;
     Logger log;
-    Boolean bindMountShared;
+    Boolean bindMountShared = false;
 
     public NVScanner(){}
 
@@ -25,7 +25,7 @@ public class NVScanner {
         this.nvRegistryUser = nvRegistryUser;
         this.nvRegistryPassword = nvRegistryPassword;
         this.log = log;
-        this.bindMountShared = bindMountShared;
+        this.bindMountShared = bindMountShared != null ? bindMountShared : false;
     }
 
     /**
@@ -36,14 +36,14 @@ public class NVScanner {
      * @param nvRegistryPassword The password to login the registry.
      * @param nvMountPath  The mount path mapping to the path inside the NeuVector Scanner container. It is the path to store the scan result. It is optional. If you don't pass in <code>nvMountPath</code>, it will use the default path "/var/neuvector"
      */
-    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Logger log , Boolean bindMountShared){
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Logger log, Boolean bindMountShared){
         this.nvRegistryURL = nvRegistryURL;
         this.nvScannerImage = nvScannerImage;
         this.nvRegistryUser = nvRegistryUser;
         this.nvRegistryPassword = nvRegistryPassword;
         this.nvMountPath = nvMountPath;
         this.log = log;
-        this.bindMountShared = bindMountShared;
+        this.bindMountShared = bindMountShared != null ? bindMountShared : false;
     }
 
     /**

--- a/src/main/java/com/neuvector/model/NVScanner.java
+++ b/src/main/java/com/neuvector/model/NVScanner.java
@@ -9,7 +9,7 @@ public class NVScanner {
     String nvRegistryPassword;
     String nvMountPath;
     Logger log;
-    Boolean isSELinuxSuffixRequired;
+    Boolean bindMountShared;
 
     public NVScanner(){}
 
@@ -19,13 +19,13 @@ public class NVScanner {
      * @param nvRegistryUser  The user name to login the registry. If the user name and the password are empty, the API will skip the docker login action.
      * @param nvRegistryPassword The password to login the registry.
      */
-    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, Logger log, Boolean isSELinuxSuffixRequired){
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, Logger log, Boolean bindMountShared){
         this.nvRegistryURL = nvRegistryURL;
         this.nvScannerImage = nvScannerImage;
         this.nvRegistryUser = nvRegistryUser;
         this.nvRegistryPassword = nvRegistryPassword;
         this.log = log;
-        this.isSELinuxSuffixRequired = isSELinuxSuffixRequired;
+        this.bindMountShared = bindMountShared;
     }
 
     /**
@@ -36,14 +36,14 @@ public class NVScanner {
      * @param nvRegistryPassword The password to login the registry.
      * @param nvMountPath  The mount path mapping to the path inside the NeuVector Scanner container. It is the path to store the scan result. It is optional. If you don't pass in <code>nvMountPath</code>, it will use the default path "/var/neuvector"
      */
-    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Logger log , Boolean isSELinuxSuffixRequired){
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Logger log , Boolean bindMountShared){
         this.nvRegistryURL = nvRegistryURL;
         this.nvScannerImage = nvScannerImage;
         this.nvRegistryUser = nvRegistryUser;
         this.nvRegistryPassword = nvRegistryPassword;
         this.nvMountPath = nvMountPath;
         this.log = log;
-        this.isSELinuxSuffixRequired = isSELinuxSuffixRequired;
+        this.bindMountShared = bindMountShared;
     }
 
     /**
@@ -120,7 +120,7 @@ public class NVScanner {
         return log;
     }
 
-    public Boolean isSELinuxSuffixRequired() {
-        return isSELinuxSuffixRequired;
+    public Boolean isBindMountShared() {
+        return bindMountShared;
     }
 }

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -40,7 +40,7 @@ public class ScannerTest
         String mountPath = mountFolder.getRoot().getAbsolutePath();
 
         Image image = new Image(imageName, imageTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null, null);
 
         ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
 
@@ -67,7 +67,35 @@ public class ScannerTest
         String mountPath = mountFolder.getRoot().getAbsolutePath();
 
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null, null);
+
+        ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
+
+        UserPrincipal user = getUserPrincipal(mountPath);
+
+        assertFalse(user.getName().equals("root"));
+        assertTrue( scanReportData != null );
+    }
+
+    @Test
+    public void scanRegistryTestAddingSELinuxSuffixToMountPath() throws IOException {
+        String license = "";
+
+        String registryURL = "https://registry.hub.docker.com";
+        String regUser = "";
+        String regPassword = "";
+        String repository = "library/alpine";
+        String repositoryTag = "3.6";
+        String nvScannerImage = "neuvector/scanner:latest";
+        String nvRegistryURL = registryURL;
+        String nvRegistryUser = null;
+        String nvRegistryPassword = null;
+        Boolean modifyVolumeMountsSELinuxLabels = Boolean.TRUE;
+        //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        String mountPath = mountFolder.getRoot().getAbsolutePath();
+
+        Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null, modifyVolumeMountsSELinuxLabels);
 
         ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
 

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -10,6 +10,8 @@ import com.neuvector.model.ScanRepoReportData;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -26,6 +28,8 @@ public class ScannerTest
     @Rule
     public TemporaryFolder mountFolder= new TemporaryFolder();
 
+    private static final Logger log = LoggerFactory.getLogger(ScannerTest.class);
+
     @Test
     public void scanLocalImageTest() throws IOException {
         String license = "";
@@ -40,7 +44,7 @@ public class ScannerTest
         String mountPath = mountFolder.getRoot().getAbsolutePath();
 
         Image image = new Image(imageName, imageTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null, null);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, log, null);
 
         ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
 
@@ -67,7 +71,7 @@ public class ScannerTest
         String mountPath = mountFolder.getRoot().getAbsolutePath();
 
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null, null);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, log, null);
 
         ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
 
@@ -92,7 +96,7 @@ public class ScannerTest
         String mountPath = mountFolder.getRoot().getAbsolutePath();
 
         Image image = new Image(imageName, imageTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null, bindMountShared);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, log, bindMountShared);
 
         ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
 
@@ -120,7 +124,7 @@ public class ScannerTest
         String mountPath = mountFolder.getRoot().getAbsolutePath();
 
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null, bindMountShared);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, log, bindMountShared);
 
         ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
 

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -78,7 +78,32 @@ public class ScannerTest
     }
 
     @Test
-    public void scanRegistryTestAddingSELinuxSuffixToMountPath() throws IOException {
+    public void scanLocalImageWhenBindMountContentIsSharedTestTest() throws IOException {
+        String license = "";
+
+        String imageName = "alpine";
+        String imageTag = "3.6";
+        String nvScannerImage = "neuvector/scanner:latest";
+        String nvRegistryUser = null;
+        String nvRegistryPassword = null;
+        String nvRegistryURL = "https://registry.hub.docker.com";
+        boolean bindMountShared = true;
+        //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        String mountPath = mountFolder.getRoot().getAbsolutePath();
+
+        Image image = new Image(imageName, imageTag);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null, bindMountShared);
+
+        ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
+
+        UserPrincipal user = getUserPrincipal(mountPath);
+
+        assertFalse(user.getName().equals("root"));
+        assertTrue( scanReportData != null );
+    }
+
+    @Test
+    public void scanRegistryWhenBindMountContentIsSharedTest() throws IOException {
         String license = "";
 
         String registryURL = "https://registry.hub.docker.com";
@@ -90,12 +115,12 @@ public class ScannerTest
         String nvRegistryURL = registryURL;
         String nvRegistryUser = null;
         String nvRegistryPassword = null;
-        Boolean modifyVolumeMountsSELinuxLabels = Boolean.TRUE;
+        boolean bindMountShared = true;
         //mountPath is an optional parameter. It will use "/var/neuvector" by default.
         String mountPath = mountFolder.getRoot().getAbsolutePath();
 
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null, modifyVolumeMountsSELinuxLabels);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, null, bindMountShared);
 
         ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
 

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -78,7 +78,7 @@ public class ScannerTest
     }
 
     @Test
-    public void scanLocalImageWhenBindMountContentIsSharedTestTest() throws IOException {
+    public void scanLocalImageTest_BindMountShared() throws IOException {
         String license = "";
 
         String imageName = "alpine";
@@ -103,7 +103,7 @@ public class ScannerTest
     }
 
     @Test
-    public void scanRegistryWhenBindMountContentIsSharedTest() throws IOException {
+    public void scanRegistryTest_BindMountShared() throws IOException {
         String license = "";
 
         String registryURL = "https://registry.hub.docker.com";


### PR DESCRIPTION

Jira ticket: https://sonatype.atlassian.net/browse/CLM-28352

When performing a container scan on an SELinux-enabled image, it will fail because the scan results cannot be written in the `/var/neuvector`. This issue is fixed by adding the `:z` suffix to the bind mount location. For example, `/var/neuvector:z`