### PR TITLE
feat: support overriding Container Runtime Command and Socket

### DIFF
--- a/src/main/java/com/neuvector/DockerRunCommandBuilder.java
+++ b/src/main/java/com/neuvector/DockerRunCommandBuilder.java
@@ -10,9 +10,13 @@ public class DockerRunCommandBuilder
 {
     private final List<String> cmdList;
 
-    public DockerRunCommandBuilder() {
+    /**
+     *
+     * @param containerRuntimeCommand Contianer Runtime Command to use - default would be `docker`.
+     */
+    public DockerRunCommandBuilder(String containerRuntimeCommand) {
         cmdList = new ArrayList<>();
-        cmdList.add("docker");
+        cmdList.add(containerRuntimeCommand);
         cmdList.add("run");
         cmdList.add("--rm");
     }

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -32,10 +32,12 @@ import org.slf4j.Logger;
  */
 public class Scanner 
 {
-
-    private static final String SOCKET_MAPPING = "/var/run/docker.sock:/var/run/docker.sock";
     private static final String CONTAINER_PATH = "/var/neuvector";
     private static final String SCAN_REPORT = "scan_result.json";
+
+    public static String GetSocketMapping(String sourceSocketPath) {
+        return String.format("%s:/var/run/docker.sock", sourceSocketPath);
+    }
 
      /**
       * To scan a docker registry and return a java bean object of com.neuvector.model.ScanRepoReportData.
@@ -61,11 +63,11 @@ public class Scanner
             reportData = new ScanRepoReportData();
             reportData.setError_message(errorMessage);
         }else{
-            DockerRunCommandBuilder builder = new DockerRunCommandBuilder();
+            DockerRunCommandBuilder builder = new DockerRunCommandBuilder(nvScanner.getContainerRuntimeCommand());
             builder
                 .withUserAndGroup(getDockerUserGroupCmdArg(getScanReportPath(nvScanner.getNvMountPath())))
                 .withName(generateScannerName())
-                .withVolume(Scanner.SOCKET_MAPPING)
+                .withVolume(Scanner.GetSocketMapping(nvScanner.getContainerRuntimeSocket()))
                 .withVolume(appendBindMountSharedSuffixIfRequired(nvScanner.isBindMountShared(), getMountPath(nvScanner), log))
                 .withEnvironment("SCANNER_REPOSITORY=" + registry.getRepository())
                 .withEnvironment("SCANNER_TAG=" + registry.getRepositoryTag())
@@ -125,11 +127,11 @@ public class Scanner
             reportData.setError_message(errorMessage);
         }else{
             String[] credentials = {license};
-            DockerRunCommandBuilder builder = new DockerRunCommandBuilder();
+            DockerRunCommandBuilder builder = new DockerRunCommandBuilder(nvScanner.getContainerRuntimeCommand());
             builder
                 .withUserAndGroup(getDockerUserGroupCmdArg(getScanReportPath(nvScanner.getNvMountPath())))
                 .withName(generateScannerName())
-                .withVolume(Scanner.SOCKET_MAPPING)
+                .withVolume(Scanner.GetSocketMapping(nvScanner.getContainerRuntimeSocket()))
                 .withVolume(appendBindMountSharedSuffixIfRequired(nvScanner.isBindMountShared(), getMountPath(nvScanner), log))
                 .withEnvironment("SCANNER_REPOSITORY=" + image.getImageName())
                 .withEnvironment("SCANNER_TAG=" + image.getImageTag())

--- a/src/main/java/com/neuvector/model/NVScanner.java
+++ b/src/main/java/com/neuvector/model/NVScanner.java
@@ -3,6 +3,15 @@ package com.neuvector.model;
 import org.slf4j.Logger;
 
 public class NVScanner {
+
+    public static String DEFAULT_CONTAINER_RUNTIME_COMMAND = "docker";
+
+    public static String CONTAINER_RUNTIME_COMMAND_PODMAN = "podman";
+
+    public static String DEFAULT_CONTAINER_RUNTIME_SOCKET = "/var/run/docker.sock";
+
+    public static String CONTAINER_RUNTIME_SOCKET_PODMAN = "/var/run/podman.sock";
+
     String nvScannerImage;
     String nvRegistryURL;
     String nvRegistryUser;
@@ -10,6 +19,10 @@ public class NVScanner {
     String nvMountPath;
     Logger log;
     Boolean bindMountShared = false;
+
+    String containerRuntimeCommand = NVScanner.DEFAULT_CONTAINER_RUNTIME_COMMAND;
+
+    String containerRuntimeSocket = NVScanner.DEFAULT_CONTAINER_RUNTIME_SOCKET;
 
     public NVScanner(){}
 
@@ -30,6 +43,48 @@ public class NVScanner {
     }
 
     /**
+     * @param nvScannerImage The name of the NeuVector Scanner image. For example, "neuvector/scanner:latest"
+     * @param nvRegistryURL  The registry from which to pull the NeuVector Scanner image. If it is empty, the API will skip the action to pull the NeuVector Scanner image.
+     * @param nvRegistryUser  The user name to login the registry. If the user name and the password are empty, the API will skip the docker login action.
+     * @param nvRegistryPassword The password to login the registry.
+     * @param bindMountShared Indicates whether the bind mount content needs to be shared. Using True when it's needed. If null is received, the default value, which is False, will be used.
+     * @param containerRuntimeCommand The container runtime command to use. Default is `docker` but could be set to `podman` for example.
+     */
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, Logger log, Boolean bindMountShared, String containerRuntimeCommand){
+        this.nvRegistryURL = nvRegistryURL;
+        this.nvScannerImage = nvScannerImage;
+        this.nvRegistryUser = nvRegistryUser;
+        this.nvRegistryPassword = nvRegistryPassword;
+        this.log = log;
+        this.bindMountShared = bindMountShared != null ? bindMountShared : false;
+        this.containerRuntimeCommand = containerRuntimeCommand;
+        if (this.containerRuntimeCommand.equals(NVScanner.CONTAINER_RUNTIME_COMMAND_PODMAN)){
+            // Default socket to default podman socket location
+            this.containerRuntimeSocket = NVScanner.CONTAINER_RUNTIME_SOCKET_PODMAN;
+        }
+    }
+
+    /**
+     * @param nvScannerImage The name of the NeuVector Scanner image. For example, "neuvector/scanner:latest"
+     * @param nvRegistryURL  The registry from which to pull the NeuVector Scanner image. If it is empty, the API will skip the action to pull the NeuVector Scanner image.
+     * @param nvRegistryUser  The user name to login the registry. If the user name and the password are empty, the API will skip the docker login action.
+     * @param nvRegistryPassword The password to login the registry.
+     * @param bindMountShared Indicates whether the bind mount content needs to be shared. Using True when it's needed. If null is received, the default value, which is False, will be used.
+     * @param containerRuntimeCommand The container runtime command to use. Default is `docker` but could be set to `podman` for example.
+     * @param containerRuntimeSocket Path to container runtime socket.
+     */
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, Logger log, Boolean bindMountShared, String containerRuntimeCommand, String containerRuntimeSocket){
+        this.nvRegistryURL = nvRegistryURL;
+        this.nvScannerImage = nvScannerImage;
+        this.nvRegistryUser = nvRegistryUser;
+        this.nvRegistryPassword = nvRegistryPassword;
+        this.log = log;
+        this.bindMountShared = bindMountShared != null ? bindMountShared : false;
+        this.containerRuntimeCommand = containerRuntimeCommand;
+        this.containerRuntimeSocket = containerRuntimeSocket;
+    }
+
+    /**
      *
      * @param nvScannerImage The name of the NeuVector Scanner image. For example, "neuvector/scanner:latest"
      * @param nvRegistryURL  The registry from which to pull the NeuVector Scanner image. If it is empty, the API will skip the action to pull the NeuVector Scanner image.
@@ -46,6 +101,54 @@ public class NVScanner {
         this.nvMountPath = nvMountPath;
         this.log = log;
         this.bindMountShared = bindMountShared != null ? bindMountShared : false;
+    }
+
+    /**
+     *
+     * @param nvScannerImage The name of the NeuVector Scanner image. For example, "neuvector/scanner:latest"
+     * @param nvRegistryURL  The registry from which to pull the NeuVector Scanner image. If it is empty, the API will skip the action to pull the NeuVector Scanner image.
+     * @param nvRegistryUser  The user name to login the registry. If the user name and the password are empty, the API will skip the docker login action.
+     * @param nvRegistryPassword The password to login the registry.
+     * @param nvMountPath  The mount path mapping to the path inside the NeuVector Scanner container. It is the path to store the scan result. It is optional. If you don't pass in <code>nvMountPath</code>, it will use the default path "/var/neuvector"
+     * @param bindMountShared Indicates whether the bind mount content needs to be shared. Using True when it's needed. If null is received, the default value, which is False, will be used.
+     * @param containerRuntimeCommand The container runtime command to use. Default is `docker` but could be set to `podman` for example.
+     */
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Logger log, Boolean bindMountShared, String containerRuntimeCommand){
+        this.nvRegistryURL = nvRegistryURL;
+        this.nvScannerImage = nvScannerImage;
+        this.nvRegistryUser = nvRegistryUser;
+        this.nvRegistryPassword = nvRegistryPassword;
+        this.nvMountPath = nvMountPath;
+        this.log = log;
+        this.bindMountShared = bindMountShared != null ? bindMountShared : false;
+        this.containerRuntimeCommand = containerRuntimeCommand;
+        if (this.containerRuntimeCommand.equals(NVScanner.CONTAINER_RUNTIME_COMMAND_PODMAN)){
+            // Default socket to default podman socket location
+            this.containerRuntimeSocket = NVScanner.CONTAINER_RUNTIME_SOCKET_PODMAN;
+        }
+    }
+
+    /**
+     *
+     * @param nvScannerImage The name of the NeuVector Scanner image. For example, "neuvector/scanner:latest"
+     * @param nvRegistryURL  The registry from which to pull the NeuVector Scanner image. If it is empty, the API will skip the action to pull the NeuVector Scanner image.
+     * @param nvRegistryUser  The user name to login the registry. If the user name and the password are empty, the API will skip the docker login action.
+     * @param nvRegistryPassword The password to login the registry.
+     * @param nvMountPath  The mount path mapping to the path inside the NeuVector Scanner container. It is the path to store the scan result. It is optional. If you don't pass in <code>nvMountPath</code>, it will use the default path "/var/neuvector"
+     * @param bindMountShared Indicates whether the bind mount content needs to be shared. Using True when it's needed. If null is received, the default value, which is False, will be used.
+     * @param containerRuntimeCommand The container runtime command to use. Default is `docker` but could be set to `podman` for example.
+     * @param containerRuntimeSocket Path to container runtime socket.
+     */
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Logger log, Boolean bindMountShared, String containerRuntimeCommand, String containerRuntimeSocket){
+        this.nvRegistryURL = nvRegistryURL;
+        this.nvScannerImage = nvScannerImage;
+        this.nvRegistryUser = nvRegistryUser;
+        this.nvRegistryPassword = nvRegistryPassword;
+        this.nvMountPath = nvMountPath;
+        this.log = log;
+        this.bindMountShared = bindMountShared != null ? bindMountShared : false;
+        this.containerRuntimeCommand = containerRuntimeCommand;
+        this.containerRuntimeSocket = containerRuntimeSocket;
     }
 
     /**
@@ -125,4 +228,8 @@ public class NVScanner {
     public Boolean isBindMountShared() {
         return bindMountShared;
     }
+
+    public String getContainerRuntimeCommand() { return this.containerRuntimeCommand; }
+
+    public String getContainerRuntimeSocket() { return this.containerRuntimeSocket; }
 }

--- a/src/test/java/com/neuvector/NvScannerTest.java
+++ b/src/test/java/com/neuvector/NvScannerTest.java
@@ -1,0 +1,84 @@
+package com.neuvector;
+
+import com.neuvector.model.NVScanner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.*;
+
+public class NvScannerTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ScannerTest.class);
+
+    @Rule
+    public TemporaryFolder mountFolder= new TemporaryFolder();
+
+    @Test
+    public void defaultAsDockerTest() {
+
+        String nvScannerImage = "neuvector/scanner:latest";
+        String nvRegistryUser = null;
+        String nvRegistryPassword = null;
+        String nvRegistryURL = "https://registry.hub.docker.com";
+        String nvMountPath = mountFolder.getRoot().getAbsolutePath();
+
+        NVScanner nvs = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, nvMountPath, log,null);
+
+        assertEquals(NVScanner.DEFAULT_CONTAINER_RUNTIME_COMMAND, nvs.getContainerRuntimeCommand());
+        assertEquals(NVScanner.DEFAULT_CONTAINER_RUNTIME_SOCKET, nvs.getContainerRuntimeSocket());
+    }
+
+    @Test
+    public void commandAsPodmanTest() {
+
+        String nvScannerImage = "neuvector/scanner:latest";
+        String nvRegistryUser = null;
+        String nvRegistryPassword = null;
+        String nvRegistryURL = "https://registry.hub.docker.com";
+        String nvMountPath = mountFolder.getRoot().getAbsolutePath();
+
+        NVScanner nvs = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, nvMountPath, log,null, "podman");
+
+        assertEquals("podman", nvs.getContainerRuntimeCommand());
+        assertEquals(NVScanner.CONTAINER_RUNTIME_SOCKET_PODMAN, nvs.getContainerRuntimeSocket());
+    }
+
+    @Test
+    public void customPodmanTest() {
+
+        String nvScannerImage = "neuvector/scanner:latest";
+        String nvRegistryUser = null;
+        String nvRegistryPassword = null;
+        String nvRegistryURL = "https://registry.hub.docker.com";
+        String nvMountPath = mountFolder.getRoot().getAbsolutePath();
+        String nvContainerCommand = "podman";
+        String nvContainerSocketPath = "/my/path.sock";
+
+        NVScanner nvs = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, nvMountPath, log,null, nvContainerCommand, nvContainerSocketPath);
+
+        assertEquals(nvContainerCommand, nvs.getContainerRuntimeCommand());
+        assertNotEquals(NVScanner.CONTAINER_RUNTIME_SOCKET_PODMAN, nvs.getContainerRuntimeSocket());
+        assertEquals(nvContainerSocketPath, nvs.getContainerRuntimeSocket());
+    }
+
+    @Test
+    public void customEverythingTest() {
+
+        String nvScannerImage = "neuvector/scanner:latest";
+        String nvRegistryUser = null;
+        String nvRegistryPassword = null;
+        String nvRegistryURL = "https://registry.hub.docker.com";
+        String nvMountPath = mountFolder.getRoot().getAbsolutePath();
+        String nvContainerCommand = "containerd";
+        String nvContainerSocketPath = "/my/to/path.sock";
+
+        NVScanner nvs = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, nvMountPath, log,null, nvContainerCommand, nvContainerSocketPath);
+
+        assertEquals(nvContainerCommand, nvs.getContainerRuntimeCommand());
+        assertNotEquals(NVScanner.CONTAINER_RUNTIME_SOCKET_PODMAN, nvs.getContainerRuntimeSocket());
+        assertEquals(nvContainerSocketPath, nvs.getContainerRuntimeSocket());
+    }
+}

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -1,8 +1,5 @@
 package com.neuvector;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import com.neuvector.model.Image;
 import com.neuvector.model.NVScanner;
 import com.neuvector.model.Registry;
@@ -19,6 +16,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileOwnerAttributeView;
 import java.nio.file.attribute.UserPrincipal;
+
+import static org.junit.Assert.*;
 
 /**
  * Unit tests
@@ -132,6 +131,29 @@ public class ScannerTest
 
         assertFalse(user.getName().equals("root"));
         assertTrue( scanReportData != null );
+    }
+
+    @Test
+    public void scanLocalImageNonExistentContainerRuntimeTest() throws IOException {
+        String license = "";
+
+        String imageName = "alpine";
+        String imageTag = "3.6";
+        String nvScannerImage = "neuvector/scanner:latest";
+        String nvRegistryUser = null;
+        String nvRegistryPassword = null;
+        String nvRegistryURL = "https://registry.hub.docker.com";
+        //mountPath is an optional parameter. It will use "/var/neuvector" by default.
+        String mountPath = mountFolder.getRoot().getAbsolutePath();
+        String nvContainerRuntimeCommand = "this-does-not-exist";
+
+        Image image = new Image(imageName, imageTag);
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, log, null, nvContainerRuntimeCommand);
+
+        ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
+
+        assertTrue( scanReportData != null );
+        assertEquals(String.format("Cannot run program \"%s\": error=2, No such file or directory", nvContainerRuntimeCommand), scanReportData.getError_message());
     }
 
     private static UserPrincipal getUserPrincipal(String mountPath) throws IOException {


### PR DESCRIPTION
A number of folk don't use Docker as their Container Runtime - instead favouring things like `podman`.

Most Container Runtimes meet or align their command syntax (at least as far as would be required by this library for its purposes).

This PR allows two things to be overridden from defaults:
1. The Container Runtime Command (default remains `docker`) - this can now be passed into `NvScanner`
2. The Container Runtime Socket (default remains `/var/run/docker.sock`) - this can now be passed into `NvScanner`

Setting Container Runtime Command to `podman` will also automatically set the runtime socket to be `/var/run/podman.sock` without the need to manually set it - however you can additionally pass that if required for your environment.

@pkiesslingsonatype 