### PR TITLE
INT-8623 - Remove mount path requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,6 @@ add scanner.jar to your classpath.
     //Login credentials to the Registry
     String nvRegUser = null;
     String nvPassword = null;
-    
-    //The path to keep the scan report. 
-    //When run it in Jenkins plugin, you can use the project's build path as the mountPath
-    String mountPath = "/temp"; 
-    // If you don't assign a value to it, it will use the default path "/var/neuvector" to save the scan report.
-    
-    boolean bindMountShared = null|true|false; //value in true, indicates that the bind mount content is shared among multiple containers
 
     // Runtime to be used to run the container. Defaults to "docker" if not provided
     String runtime = "docker";
@@ -48,8 +41,8 @@ add scanner.jar to your classpath.
     // Socketmapping for docker in docker environments. Defaults to /var/run/docker.sock:/var/run/docker.sock if not overridden. 
     String socketMapping = "/var/run/docker.sock:/var/run/docker.sock"
     
-    // NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, log, bindMountShared)
-    com.neuvector.model.NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, bindMountShared, runtime, socketMapping);
+    // NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, log)
+    com.neuvector.model.NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, runtime, socketMapping);
 
     //NeuVector license to run the Scanner
     String license = "xxx";  
@@ -90,15 +83,14 @@ add scanner.jar to your classpath.
     //Login credentials to the Registry
     String nvRegUser = "";
     String nvPassword = "";
-    String mountPath = "/temp"; //The path to keep the scan report. If you don't assign a value to it, it will use the path "/var/neuvector" by default.
-    boolean bindMountShared = null|true|false; //value in true, indicates that the bind mount content is shared among multiple containers
+
     // Runtime to be used to run the container. Defaults to docker if not provided
     String runtime = "docker";
 
     // Socketmapping for docker in docker environments. Defaults to /var/run/docker.sock:/var/run/docker.sock if not overridden. 
     String socketMapping = "/var/run/docker.sock:/var/run/docker.sock"
     
-    com.neuvector.model.NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryUrl, nvRegUser, nvPassword, mountPath, bindMountShared, runtime, socketMapping);
+    com.neuvector.model.NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryUrl, nvRegUser, nvPassword, runtime, socketMapping);
 
     // The scan result will be returned as a java bean object
     com.neuvector.model.ScanRepoReportData scanReportData = com.neuvector.Scanner.scanRegistry(registry, scanner, license);

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.neuvector</groupId>
   <artifactId>scanner</artifactId>
-  <version>1.12</version>
+  <version>1.13</version>
   <packaging>jar</packaging>
 
   <name>NeuVector Scanner API</name>

--- a/src/main/java/com/neuvector/DockerRunCommandBuilder.java
+++ b/src/main/java/com/neuvector/DockerRunCommandBuilder.java
@@ -23,17 +23,9 @@ public class DockerRunCommandBuilder
         cmdList.add("--rm");
     }
 
-    DockerRunCommandBuilder withUserAndGroup(String userIdGroupId) {
-        if (userIdGroupId != null && userIdGroupId.length() > 0) {
-            cmdList.add("-u");
-            cmdList.add(userIdGroupId);
-        }
-        return this;
-    }
-
-    DockerRunCommandBuilder withName(String name) {
-        cmdList.add("--name");
-        cmdList.add(name);
+    DockerRunCommandBuilder withEntrypoint(String command) {
+        cmdList.add("--entrypoint");
+        cmdList.add(command);
         return this;
     }
 
@@ -52,8 +44,18 @@ public class DockerRunCommandBuilder
         return this;
     }
 
-    String[] buildForImage(String image) {
+    DockerRunCommandBuilder withImage(String image) {
         cmdList.add(image);
-        return cmdList.toArray(new String[0]);
+        return this;
+    }
+
+    DockerRunCommandBuilder withCommand(String command) {
+        cmdList.add("-c");
+        cmdList.add(command);
+        return this;
+    }
+
+    public List<String> getCmdList() {
+        return cmdList;
     }
 }

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -217,8 +217,14 @@ public class Scanner
     }
 
     private static ScanRepoReportData parseScanReport(String reportJson){
-        ScanRepoReportData scanReportData = new Gson().fromJson(reportJson, ScanRepoReportData.class);
-        return scanReportData;
+        try {
+            ScanRepoReportData scanReportData = new Gson().fromJson(reportJson, ScanRepoReportData.class);
+            return scanReportData;
+        } catch (Exception e) {
+            ScanRepoReportData scanRepoReportData = new ScanRepoReportData();
+            scanRepoReportData.setError_message(e.getMessage());
+            return scanRepoReportData;
+        }
     }
 
     private static String runCMD(String[] cmdArgs, Logger log, StringBuilder outputCollector){

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -236,13 +236,17 @@ public class Scanner
                 if (outputCollector != null) {
                     outputCollector.append(s);
                 }
-                if ("scan_result.json".equals(s)) {
-                    // Do not print out scan_result.json in logs as it might get quite large (thousands of lines)
-                    // Stop logging after we encounter scan_result.json
-                    catScanResultJsonOutput = true;
-                }
                 // sb.append(System.getProperty("line.separator"));
                 if (log != null) {
+                    if ("scan_result.json".equals(s)) {
+                        // Do not print out scan_result.json in logs as it might get quite large (thousands of lines)
+                        // Stop logging after we encounter scan_result.json
+                        catScanResultJsonOutput = true;
+                        if (!log.isDebugEnabled()) {
+                            log.info("If debug mode is enabled, the contents of scan_result.json can be observed in the logs.");
+                            log.info("Contents of scan_result.json are not included at info level.");
+                        }
+                    }
                     if (catScanResultJsonOutput) {
                         log.debug(s);
                     } else {

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -1,17 +1,8 @@
 package com.neuvector;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.FileOwnerAttributeView;
-import java.nio.file.attribute.UserPrincipal;
-import java.util.Random;
-import java.util.stream.Stream;
 
 import com.google.gson.Gson;
 import com.neuvector.model.Image;
@@ -34,8 +25,6 @@ public class Scanner
 {
 
     public static final String SOCKET_MAPPING = "/var/run/docker.sock:/var/run/docker.sock";
-    private static final String CONTAINER_PATH = "/var/neuvector";
-    private static final String SCAN_REPORT = "scan_result.json";
 
      /**
       * To scan a docker registry and return a java bean object of com.neuvector.model.ScanRepoReportData.
@@ -63,10 +52,8 @@ public class Scanner
         }else{
             DockerRunCommandBuilder builder = new DockerRunCommandBuilder(nvScanner.getRuntime());
             builder
-                .withUserAndGroup(getDockerUserGroupCmdArg(getScanReportPath(nvScanner.getNvMountPath())))
-                .withName(generateScannerName())
+                .withEntrypoint("/usr/bin/bash")
                 .withVolume(nvScanner.getSocketMapping())
-                .withVolume(appendBindMountSharedSuffixIfRequired(nvScanner.isBindMountShared(), getMountPath(nvScanner), log))
                 .withEnvironment("SCANNER_REPOSITORY=" + registry.getRepository())
                 .withEnvironment("SCANNER_TAG=" + registry.getRepositoryTag())
                 .withEnvironment("SCANNER_LICENSE=" + license)
@@ -80,9 +67,12 @@ public class Scanner
                     .withEnvironment("SCANNER_REGISTRY_USERNAME=" + registry.getLoginUser())
                     .withEnvironment("SCANNER_REGISTRY_PASSWORD=" + registry.getLoginPassword());
             }
-            String[] cmdArgs = builder.buildForImage(getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL()));
+            builder.withImage(getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL()));
+            builder.withCommand("/usr/local/bin/monitor && echo 'scan_result.json' && cat /var/neuvector/scan_result.json");
             String[] credentials = {registry.getLoginPassword(), license};
-            reportData = runScan(cmdArgs, nvScanner, credentials);
+            String[] runCmd = builder.getCmdList().toArray(new String[0]);
+            log.info("Running container scan via: {}", String.join(" ", masked(runCmd)));
+            reportData = runScan(runCmd, nvScanner, credentials);
         }
 
         return reportData;
@@ -127,10 +117,8 @@ public class Scanner
             String[] credentials = {license};
             DockerRunCommandBuilder builder = new DockerRunCommandBuilder(nvScanner.getRuntime());
             builder
-                .withUserAndGroup(getDockerUserGroupCmdArg(getScanReportPath(nvScanner.getNvMountPath())))
-                .withName(generateScannerName())
+                .withEntrypoint("/usr/bin/bash")
                 .withVolume(nvScanner.getSocketMapping())
-                .withVolume(appendBindMountSharedSuffixIfRequired(nvScanner.isBindMountShared(), getMountPath(nvScanner), log))
                 .withEnvironment("SCANNER_REPOSITORY=" + image.getImageName())
                 .withEnvironment("SCANNER_TAG=" + image.getImageTag())
                 .withEnvironment("SCANNER_LICENSE=" + license)
@@ -138,9 +126,11 @@ public class Scanner
             if( scanLayers ){
                 builder.withEnvironment("SCANNER_SCAN_LAYERS=true");
             }
-            String[] cmdArgs = builder.buildForImage(getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL()));
-            log.info("Running container scan via: {}", String.join(" ", cmdArgs));
-            reportData = runScan(cmdArgs, nvScanner, credentials);
+            builder.withImage(getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL()));
+            builder.withCommand("/usr/local/bin/monitor && echo 'scan_result.json' && cat /var/neuvector/scan_result.json");
+            String[] runCmd = builder.getCmdList().toArray(new String[0]);
+            log.info("Running container scan via: {}", String.join(" ", masked(runCmd)));
+            reportData = runScan(runCmd, nvScanner, credentials);
         }
 
         return reportData;
@@ -185,16 +175,16 @@ public class Scanner
 
         if(!nvRegistryUser.equals("") && !nvRegistryPassword.equals("")){
             String[] cmdArgsDockerLogin = {"docker", "login", "-u", nvRegistryUser, "-p", nvRegistryPassword, nvRegistryURL};
-            errorMessage = runCMD(cmdArgsDockerLogin, log);
+            errorMessage = runCMD(cmdArgsDockerLogin, log, null);
             if(errorMessage.length() == 0){
                 String[] cmdArgsDockerPull = {"docker", "pull", getNVImagePath(nvScannerImage, nvRegistryURL)};
-                errorMessage = runCMD(cmdArgsDockerPull, log);
+                errorMessage = runCMD(cmdArgsDockerPull, log, null);
                 String[] cmdArgsDockerLogout = {"docker", "logout"};
-                errorMessage = runCMD(cmdArgsDockerLogout, log);
+                errorMessage = errorMessage + "" + runCMD(cmdArgsDockerLogout, log, null);
             }
         } else {
             String[] cmdArgsDockPull = {"docker", "pull", getNVImagePath(nvScannerImage, nvRegistryURL)};
-            errorMessage = runCMD(cmdArgsDockPull, log);
+            errorMessage = runCMD(cmdArgsDockPull, log, null);
         }
 
         // mask the password in the error message
@@ -226,29 +216,12 @@ public class Scanner
         return nvImagePath;
     }
 
-    private static ScanRepoReportData parseScanReport(String scanReportPath){
-        ScanRepoReportData scanReportData;
-        StringBuilder contentBuilder = new StringBuilder();
-        String errorMessage = null;
-
-        try (Stream<String> stream = Files.lines(Paths.get(scanReportPath), StandardCharsets.UTF_8)) {
-            stream.forEach(s -> contentBuilder.append(s).append("\n"));
-        } catch (IOException ex) {
-            errorMessage = ex.getMessage();
-        }
-
-        if(errorMessage != null){
-            scanReportData = new ScanRepoReportData();
-            scanReportData.setError_message(errorMessage);
-        }else{
-            scanReportData = new Gson().fromJson(contentBuilder.toString(), ScanRepoReportData.class);
-        }
-
+    private static ScanRepoReportData parseScanReport(String reportJson){
+        ScanRepoReportData scanReportData = new Gson().fromJson(reportJson, ScanRepoReportData.class);
         return scanReportData;
-
     }
 
-    private static String runCMD(String[] cmdArgs, Logger log){
+    private static String runCMD(String[] cmdArgs, Logger log, StringBuilder outputCollector){
         Process process;
         String errorMessage = "";
         try {
@@ -258,10 +231,23 @@ public class Scanner
             // Read the output from the command
             String s = null;
             StringBuilder sb = new StringBuilder(String.join(" ", cmdArgs));
+            boolean catScanResultJsonOutput = false;
             while ((s = stdInput.readLine()) != null) {
+                if (outputCollector != null) {
+                    outputCollector.append(s);
+                }
+                if ("scan_result.json".equals(s)) {
+                    // Do not print out scan_result.json in logs as it might get quite large (thousands of lines)
+                    // Stop logging after we encounter scan_result.json
+                    catScanResultJsonOutput = true;
+                }
                 // sb.append(System.getProperty("line.separator"));
                 if (log != null) {
-                    log.info(s);
+                    if (catScanResultJsonOutput) {
+                        log.debug(s);
+                    } else {
+                        log.info(s);
+                    }
                 }
                 sb.append(s);
             }
@@ -290,8 +276,8 @@ public class Scanner
     }
 
     private static ScanRepoReportData runScan(String[] cmdArgs, NVScanner nvScanner, String[] credentials) {
-
-        String errorMessage = runCMD(cmdArgs, nvScanner.getLog());
+        StringBuilder outputCollector = new StringBuilder();
+        String errorMessage = runCMD(cmdArgs, nvScanner.getLog(), outputCollector);
 
         ScanRepoReportData reportData = null;
 
@@ -305,143 +291,28 @@ public class Scanner
             reportData = new ScanRepoReportData();
             reportData.setError_message(errorMessage);
         }else{
-            reportData = parseScanReport(getScanReportPath(nvScanner.getNvMountPath()));
+            String scanResultJson = "scan_result.json";
+            String reportJsonString = outputCollector.substring(outputCollector.toString().indexOf(scanResultJson) + scanResultJson.length());
+            reportData = parseScanReport(reportJsonString);
         }
 
         return reportData;
-    }
-
-    private static String getMountPath(NVScanner nvScanner){
-        String mountPath = ":" + CONTAINER_PATH;
-        String nvPath = nvScanner.getNvMountPath();
-        if( nvPath != null && nvPath.length() > 0){
-            if( nvPath.charAt(nvPath.length() - 1) == '/' ){
-                nvPath = nvPath.substring(0, nvPath.length() - 1);
-            }
-            mountPath = nvPath + mountPath;
-        }else {
-            mountPath = CONTAINER_PATH + mountPath;
-        }
-        return mountPath;
-    }
-
-    private static String appendBindMountSharedSuffixIfRequired(final Boolean isBindMountShared, final String mountPath, final Logger log) {
-        String updatedMountPath = mountPath;
-        if(isBindMountShared != null && isBindMountShared){
-            updatedMountPath = new StringBuilder(mountPath).append(":z").toString();
-        }
-        log.info("Using volume binding: {}", updatedMountPath);
-        return updatedMountPath;
-    }
-
-    private static String getScanReportPath(String path){
-        String scanReportPath = "";
-        if(path == null || path.length() == 0){
-            scanReportPath = CONTAINER_PATH + "/" + SCAN_REPORT;
-        }else{
-            scanReportPath = removeLastSlash(path) + "/" + SCAN_REPORT;
-        }
-
-        return scanReportPath;
-    }
-
-    private static String removeLastSlash(String str){
-        if(str != null && str.length() > 0 && str.charAt(str.length() - 1) == '/'){
-            return str.substring(0, str.length() - 1);
-        }else{
-            return str;
-        }
-    }
-
-    private static String generateScannerName(){
-            String SALTCHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-            StringBuilder salt = new StringBuilder();
-            Random rnd = new Random();
-            while (salt.length() < 6) { // length of the random string.
-                int index = (int) (rnd.nextFloat() * SALTCHARS.length());
-                salt.append(SALTCHARS.charAt(index));
-            }
-            String saltStr = salt.toString();
-            return saltStr;
     }
 
     private static String maskCredential(String message, String credential){
         return message.replace(credential, "******");
     }
 
-    static String getDockerUserGroupCmdArg(String scanReportPath) {
-        // No user arg if file exists, and it is owned by root
-        Boolean ownedByRoot = ownedByRoot(scanReportPath);
-        if (ownedByRoot != null && ownedByRoot) {
-            return null;
-        }
+    public static String[] masked(String[] runCmd) {
+        String[] masked = new String[runCmd.length];
 
-        String cmdUserGroupArg = null;
-        String UID = executeCommand("id -u");
-        if ((UID != null && !UID.isEmpty())) {
-            if ("0".equals(UID)) {
-                return null; // runs as root
-            }
-            String GID = executeCommand("stat -c '%g' /var/run/docker.sock");
-            if ((GID != null && !GID.isEmpty())) {
-                cmdUserGroupArg = UID + ":" + GID.replace("'", "");
+        for (int i = 0; i < runCmd.length; i++) {
+            masked[i] = runCmd[i];
+            if (masked[i] != null && masked[i].startsWith("SCANNER_REGISTRY_PASSWORD=")) {
+                masked[i] = "SCANNER_REGISTRY_PASSWORD=****";
             }
         }
-        return cmdUserGroupArg;
-    }
 
-    private static Boolean ownedByRoot(String scanReportPath)  {
-        File scanResultFileJson = new File(scanReportPath);
-        try {
-            return scanResultsFileExist(scanReportPath) && "root".equals(getUserPrincipal(scanReportPath, scanResultFileJson).getName());
-        } catch (IOException e) {
-            return null;
-        }
+        return masked;
     }
-
-    private static String executeCommand(String command) {
-        StringBuilder output = new StringBuilder();
-        try {
-            Process proc = Runtime.getRuntime().exec(command);
-            getExecValueFromBuffer(output, proc);
-        } catch (Exception e) {
-            return null;
-        }
-        return output.toString();
-    }
-
-    private static void getExecValueFromBuffer(StringBuilder output, Process proc) throws IOException, InterruptedException {
-        String line;
-        try (BufferedReader reader =
-                     new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
-            while ((line = reader.readLine()) != null) {
-                output.append(line);
-            }
-            proc.waitFor();
-        }
-    }
-
-    private static boolean scanResultsFileExist(String scanResultFilePath) {
-        File scanResultFile = new File(scanResultFilePath);
-        return scanResultFile.exists();
-    }
-
-    private static UserPrincipal getUserPrincipal(String mountPath, File file) throws IOException {
-        UserPrincipal user = null;
-        if (file.exists()) {
-            Path path = Paths.get(mountPath);
-            FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
-                    FileOwnerAttributeView.class);
-            user = fileOwner.getOwner();
-        }
-        return user;
-    }
-
-    public static String deleteDockerImagesByLabelKey(String label) {
-        String errorMessage = "";
-        String[] cmdArgsDockerDelete = {"docker", "image", "prune", "--force", "--filter=label=".concat(label)};
-        errorMessage = runCMD(cmdArgsDockerDelete, null);
-        return errorMessage;
-    }
-
 }

--- a/src/main/java/com/neuvector/model/NVScanner.java
+++ b/src/main/java/com/neuvector/model/NVScanner.java
@@ -8,9 +8,7 @@ public class NVScanner {
     String nvRegistryURL;
     String nvRegistryUser;
     String nvRegistryPassword;
-    String nvMountPath;
     Logger log;
-    Boolean bindMountShared = false;
     String runtime = "docker";
     String socketMapping = Scanner.SOCKET_MAPPING;
 
@@ -21,15 +19,13 @@ public class NVScanner {
      * @param nvRegistryURL  The registry from which to pull the NeuVector Scanner image. If it is empty, the API will skip the action to pull the NeuVector Scanner image.
      * @param nvRegistryUser  The user name to login the registry. If the user name and the password are empty, the API will skip the docker login action.
      * @param nvRegistryPassword The password to login the registry.
-     * @param bindMountShared Indicates whether the bind mount content needs to be shared. Using True when it's needed. If null is received, the default value, which is False, will be used.
      */
-    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, Logger log, Boolean bindMountShared){
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, Logger log){
         this.nvRegistryURL = nvRegistryURL;
         this.nvScannerImage = nvScannerImage;
         this.nvRegistryUser = nvRegistryUser;
         this.nvRegistryPassword = nvRegistryPassword;
         this.log = log;
-        this.bindMountShared = bindMountShared != null ? bindMountShared : false;
     }
 
     /**
@@ -38,19 +34,15 @@ public class NVScanner {
      * @param nvRegistryURL  The registry from which to pull the NeuVector Scanner image. If it is empty, the API will skip the action to pull the NeuVector Scanner image.
      * @param nvRegistryUser  The user name to login the registry. If the user name and the password are empty, the API will skip the docker login action.
      * @param nvRegistryPassword The password to login the registry.
-     * @param nvMountPath  The mount path mapping to the path inside the NeuVector Scanner container. It is the path to store the scan result. It is optional. If you don't pass in <code>nvMountPath</code>, it will use the default path "/var/neuvector"
-     * @param bindMountShared Indicates whether the bind mount content needs to be shared. Using True when it's needed. If null is received, the default value, which is False, will be used.
      * @param runtime Indicates which runtime platform will be used to invoke the neuvector image. Examples can be docker, podman etc.. If not provided, will default to docker
      * @param socketMapping Socket mapping argument to be used. This is needed for docker in docker environments. Default value is the Scanner.SOCKET_MAPPING constant
      */
-    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, String nvMountPath, Logger log, Boolean bindMountShared, String runtime, String socketMapping){
+    public NVScanner(String nvScannerImage, String nvRegistryURL, String nvRegistryUser, String nvRegistryPassword, Logger log, String runtime, String socketMapping){
         this.nvRegistryURL = nvRegistryURL;
         this.nvScannerImage = nvScannerImage;
         this.nvRegistryUser = nvRegistryUser;
         this.nvRegistryPassword = nvRegistryPassword;
-        this.nvMountPath = nvMountPath;
         this.log = log;
-        this.bindMountShared = bindMountShared != null ? bindMountShared : false;
         if (runtime != null) {
             this.runtime = runtime;
         }
@@ -115,26 +107,8 @@ public class NVScanner {
         this.nvRegistryPassword = nvRegistryPassword;
     }
 
-    /**
-     * @return String
-     */
-    public String getNvMountPath() {
-        return nvMountPath;
-    }
-
-    /**
-     * @param nvMountPath The file path to save the scan report.
-     */
-    public void setNvMountPath(String nvMountPath) {
-        this.nvMountPath = nvMountPath;
-    }
-    
     public Logger getLog() {
         return log;
-    }
-
-    public Boolean isBindMountShared() {
-        return bindMountShared;
     }
 
     public String getRuntime() {

--- a/src/test/java/com/neuvector/ScannerTest.java
+++ b/src/test/java/com/neuvector/ScannerTest.java
@@ -1,37 +1,25 @@
 package com.neuvector;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.neuvector.model.Image;
 import com.neuvector.model.NVScanner;
 import com.neuvector.model.Registry;
 import com.neuvector.model.ScanRepoReportData;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.FileOwnerAttributeView;
-import java.nio.file.attribute.UserPrincipal;
 
 /**
  * Unit tests
  */
 public class ScannerTest 
 {
-    @Rule
-    public TemporaryFolder mountFolder= new TemporaryFolder();
-
     private static final Logger log = LoggerFactory.getLogger(ScannerTest.class);
 
     @Test
-    public void scanLocalImageTest() throws IOException {
+    public void scanLocalImageTest() {
         String license = "";
 
         String imageName = "alpine";
@@ -40,22 +28,19 @@ public class ScannerTest
         String nvRegistryUser = null;
         String nvRegistryPassword = null;
         String nvRegistryURL = "https://registry.hub.docker.com";
-        //mountPath is an optional parameter. It will use "/var/neuvector" by default.
-        String mountPath = mountFolder.getRoot().getAbsolutePath();
 
         Image image = new Image(imageName, imageTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, log, null, "docker", "");
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, log, "docker", "");
 
         ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
 
-        UserPrincipal user = getUserPrincipal(mountPath);
-
-        assertFalse(user.getName().equals("root"));
         assertTrue( scanReportData != null );
+        assertEquals("", scanReportData.getError_message());
+        assertTrue(scanReportData.getReport().getBase_os().startsWith("alpine"));
     }
 
     @Test
-    public void scanRegistryTest() throws IOException {
+    public void scanRegistryTest() {
         String license = "";
 
         String registryURL = "https://registry.hub.docker.com";
@@ -67,79 +52,14 @@ public class ScannerTest
         String nvRegistryURL = registryURL;
         String nvRegistryUser = null;
         String nvRegistryPassword = null;
-        //mountPath is an optional parameter. It will use "/var/neuvector" by default.
-        String mountPath = mountFolder.getRoot().getAbsolutePath();
 
         Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, log, null, "docker", "");
+        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, log, "docker", "");
 
         ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
 
-        UserPrincipal user = getUserPrincipal(mountPath);
-
-        assertFalse(user.getName().equals("root"));
         assertTrue( scanReportData != null );
-    }
-
-    @Test
-    public void scanLocalImageTest_BindMountShared() throws IOException {
-        String license = "";
-
-        String imageName = "alpine";
-        String imageTag = "3.6";
-        String nvScannerImage = "neuvector/scanner:latest";
-        String nvRegistryUser = null;
-        String nvRegistryPassword = null;
-        String nvRegistryURL = "https://registry.hub.docker.com";
-        boolean bindMountShared = true;
-        //mountPath is an optional parameter. It will use "/var/neuvector" by default.
-        String mountPath = mountFolder.getRoot().getAbsolutePath();
-
-        Image image = new Image(imageName, imageTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, log, bindMountShared, "docker", "");
-
-        ScanRepoReportData scanReportData = Scanner.scanLocalImage(image,scanner,license);
-
-        UserPrincipal user = getUserPrincipal(mountPath);
-
-        assertFalse(user.getName().equals("root"));
-        assertTrue( scanReportData != null );
-    }
-
-    @Test
-    public void scanRegistryTest_BindMountShared() throws IOException {
-        String license = "";
-
-        String registryURL = "https://registry.hub.docker.com";
-        String regUser = "";
-        String regPassword = "";
-        String repository = "library/alpine";
-        String repositoryTag = "3.6";
-        String nvScannerImage = "neuvector/scanner:latest";
-        String nvRegistryURL = registryURL;
-        String nvRegistryUser = null;
-        String nvRegistryPassword = null;
-        boolean bindMountShared = true;
-        //mountPath is an optional parameter. It will use "/var/neuvector" by default.
-        String mountPath = mountFolder.getRoot().getAbsolutePath();
-
-        Registry registry = new Registry(registryURL, regUser, regPassword,repository,repositoryTag);
-        NVScanner scanner = new NVScanner(nvScannerImage, nvRegistryURL, nvRegistryUser, nvRegistryPassword, mountPath, log, bindMountShared, "docker", "");
-
-        ScanRepoReportData scanReportData = Scanner.scanRegistry(registry, scanner, license);
-
-        UserPrincipal user = getUserPrincipal(mountPath);
-
-        assertFalse(user.getName().equals("root"));
-        assertTrue( scanReportData != null );
-    }
-
-    private static UserPrincipal getUserPrincipal(String mountPath) throws IOException {
-        UserPrincipal user = null;
-        Path path = Paths.get(mountPath + "/scan_result.json");
-        FileOwnerAttributeView fileOwner = Files.getFileAttributeView(path,
-                FileOwnerAttributeView.class);
-        user = fileOwner.getOwner();
-        return user;
+        assertEquals("", scanReportData.getError_message());
+        assertTrue(scanReportData.getReport().getBase_os().startsWith("alpine"));
     }
 }


### PR DESCRIPTION
Instead of using the shared file system and a shared folder, `cat` the `scan_result.json` contents while the container is running after the scan and capture the contents from the output. 

This eliminates the need of binding a volume and sharing a folder with the container in the base file system. 

https://sonatype.atlassian.net/browse/INT-8623